### PR TITLE
feat(auth): social login + signup CTAs on /login

### DIFF
--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -33,6 +33,7 @@ import {
   createFileRoute,
   useNavigate,
   useRouter,
+  Link,
 } from "@tanstack/react-router";
 
 import {
@@ -43,6 +44,8 @@ import {
   completeTotp,
   verifyEmail,
 } from "@/server/auth.functions";
+
+import { startProviderAuth } from "@/server/hosted-auth.functions";
 
 import {
   FieldDescription,
@@ -619,11 +622,34 @@ function LoginPage() {
           <CardTitle className="text-lg">{heading}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          {step === "credentials" && (
+            <>
+              <SocialAuthButtons
+                disabled={isBusy}
+                returnTo={returnTo}
+              />
+              <OrSeparator />
+            </>
+          )}
+
           {step === "credentials" && renderCredentials()}
           {step === "email_verification" && renderEmailVerification()}
           {(step === "mfa_enrollment" || step === "mfa_challenge") &&
             renderTotp()}
           {step === "organization_selection" && renderOrganizations()}
+
+          {step === "credentials" && (
+            <p className="text-center text-sm text-muted-foreground">
+              No account?{" "}
+              <Link
+                to="/signup"
+                search={{ returnTo }}
+                className="font-medium underline-offset-4 hover:underline"
+              >
+                Sign up
+              </Link>
+            </p>
+          )}
 
           {step !== "credentials" && (
             <Button
@@ -638,6 +664,59 @@ function LoginPage() {
           )}
         </CardContent>
       </Card>
+    </div>
+  );
+}
+
+function SocialAuthButtons({
+  disabled,
+  returnTo,
+}: {
+  disabled: boolean;
+  returnTo: string;
+}) {
+  const handleProvider = (provider: "GoogleOAuth" | "GitHubOAuth") => {
+    // startProviderAuth is a server fn that throws a redirect; navigate the
+    // browser to its endpoint to follow the 302 to WorkOS.
+    void startProviderAuth({ data: { provider, returnTo } });
+  };
+
+  return (
+    <FieldGroup>
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        disabled={disabled}
+        onClick={() => handleProvider("GoogleOAuth")}
+      >
+        Continue with Google
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        disabled={disabled}
+        onClick={() => handleProvider("GitHubOAuth")}
+      >
+        Continue with GitHub
+      </Button>
+    </FieldGroup>
+  );
+}
+
+function OrSeparator() {
+  return (
+    <div className="relative my-2">
+      <div
+        className="absolute inset-0 flex items-center"
+        aria-hidden="true"
+      >
+        <div className="w-full border-t border-zinc-200" />
+      </div>
+      <div className="relative flex justify-center text-xs uppercase">
+        <span className="bg-background px-2 text-muted-foreground">or</span>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds **Continue with Google** and **Continue with GitHub** buttons above the embedded email/password form on `/login`.
- Adds visual `or` separator between social CTAs and the email form.
- Adds a "Sign up" link in the footer that points at `/signup` (introduced in PR 1).
- Buttons call `startProviderAuth({ provider: "GoogleOAuth" | "GitHubOAuth" })` from PR 1 — direct provider entry, skips the AuthKit chooser.

This PR validates hosted social round-trips end-to-end while the embedded password / TOTP / org-selection flow remains as a fallback. PR 3 cuts that fallback over to hosted.

## Stack — PR 2 of 4
- PR 1 feat(auth): hosted auth server fns + /signup route
- ▶ **PR 2** feat(auth): social login + signup CTAs on /login ← *this PR*
- PR 3 feat(auth): redirect /login to hosted UI
- PR 4 chore(auth): remove embedded auth code

## Test plan
- [x] `pnpm -F web exec tsc --noEmit` → exit 0
- [x] `pnpm -F web test` → 12/12 pass
- [ ] Manual: click Google → consent → callback → Convex `users` row created
- [ ] Manual: click GitHub → same round-trip
- [ ] Manual: existing email/password login still works
- [ ] Manual: "Sign up" link → /signup → hosted page

🤖 Generated with [Claude Code](https://claude.com/claude-code)