### PR TITLE
feat(auth): add seedSuperAdmin bootstrap action

### DIFF
--- a/packages/backend/convex/__tests__/adminUserManagement.test.ts
+++ b/packages/backend/convex/__tests__/adminUserManagement.test.ts
@@ -67,7 +67,7 @@ describe("assertRoleChangeAllowed", () => {
         newRole: AdminRole.OPERATIONS,
         activeSuperAdminCount: 5,
       }),
-    ).toThrowError(ConvexError);
+    ).toThrow(ConvexError);
   });
 
   it("rejects demoting the last active super-admin", () => {
@@ -83,7 +83,7 @@ describe("assertRoleChangeAllowed", () => {
         newRole: AdminRole.OPERATIONS,
         activeSuperAdminCount: 1,
       }),
-    ).toThrowError(ConvexError);
+    ).toThrow(ConvexError);
   });
 
   it("allows demoting a super-admin when more than one active super-admin exists", () => {
@@ -130,7 +130,7 @@ describe("assertDeactivationAllowed", () => {
         target: self,
         activeSuperAdminCount: 5,
       }),
-    ).toThrowError(ConvexError);
+    ).toThrow(ConvexError);
   });
 
   it("rejects deactivating an already-deactivated admin", () => {
@@ -141,7 +141,7 @@ describe("assertDeactivationAllowed", () => {
         target,
         activeSuperAdminCount: 5,
       }),
-    ).toThrowError(ConvexError);
+    ).toThrow(ConvexError);
   });
 
   it("rejects deactivating the last active super-admin", () => {
@@ -156,7 +156,7 @@ describe("assertDeactivationAllowed", () => {
         target,
         activeSuperAdminCount: 1,
       }),
-    ).toThrowError(ConvexError);
+    ).toThrow(ConvexError);
   });
 
   it("allows deactivating a super-admin when more than one active exists", () => {

--- a/packages/backend/convex/admin.ts
+++ b/packages/backend/convex/admin.ts
@@ -41,6 +41,7 @@ const adminViewerValidator = v.object({
   created_at: v.number(),
   deleted_at: v.optional(v.number()),
   last_login_at: v.nullable(v.number()),
+  _creationTime: v.number(),
 });
 
 const adminOperationsSummaryValidator = v.object({

--- a/packages/backend/convex/init.ts
+++ b/packages/backend/convex/init.ts
@@ -1,6 +1,8 @@
 import { Crons } from "@convex-dev/crons";
+import { v } from "convex/values";
 
-import { internalAction } from "./_generated/server";
+import { RESOURCE_TYPE, TABLE_NAMES, UserStatus, AdminRole } from "./shared";
+import { internalAction, internalMutation } from "./_generated/server";
 import { components, internal } from "./_generated/api";
 import { auditLog } from "./auditLog";
 
@@ -56,5 +58,134 @@ export const setup = internalAction({
         `Successfully registered cron job '${job.name}' via the crons component.`,
       );
     }
+  },
+});
+
+// ============================================================================
+// Super-admin bootstrap
+// ============================================================================
+
+/**
+ * One-time bootstrap: create (or promote) the first super-admin admin_users record.
+ *
+ * This action is only callable via the Convex CLI — it cannot be invoked from
+ * the browser. It is safe to run multiple times (idempotent).
+ *
+ * Usage (run once after deployment):
+ *   npx convex run init:seedSuperAdmin
+ *
+ * Prerequisites:
+ *   - SUPER_ADMIN_EMAIL must be set as a Convex environment variable:
+ *       npx convex env set SUPER_ADMIN_EMAIL you@example.com
+ *   - WORKOS_API_KEY must be set as a Convex environment variable.
+ *   - A WorkOS user with that email must already exist (sign up via the app
+ *     or create manually in the WorkOS dashboard).
+ */
+export const seedSuperAdmin = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const email = process.env.SUPER_ADMIN_EMAIL?.trim().toLowerCase();
+    if (!email) {
+      throw new Error(
+        "SUPER_ADMIN_EMAIL env var is not set. " +
+          "Run: npx convex env set SUPER_ADMIN_EMAIL you@example.com",
+      );
+    }
+
+    const apiKey = process.env.WORKOS_API_KEY;
+    if (!apiKey) {
+      throw new Error("WORKOS_API_KEY env var is not set.");
+    }
+
+    // Look up the existing WorkOS user by email.
+    const resp = await fetch(
+      `https://api.workos.com/user_management/users?email=${encodeURIComponent(email)}`,
+      {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    if (!resp.ok) {
+      throw new Error(`WorkOS user lookup failed (HTTP ${resp.status})`);
+    }
+
+    const body = (await resp.json()) as {
+      data?: { id: string; first_name?: string; last_name?: string }[];
+    };
+    const workosUser = body.data?.[0];
+
+    if (!workosUser) {
+      throw new Error(
+        `No WorkOS user found for "${email}". ` +
+          "Create the user in the WorkOS dashboard (or have them sign up) first.",
+      );
+    }
+
+    await ctx.runMutation(internal.init._upsertSuperAdmin, {
+      workosId: workosUser.id,
+      email,
+      first_name: workosUser.first_name ?? "",
+      last_name: workosUser.last_name ?? "",
+    });
+  },
+});
+
+/**
+ * Internal mutation used exclusively by seedSuperAdmin.
+ * Upserts an admin_users row with the super-admin role:
+ *   - If a row already exists with super-admin role → no-op.
+ *   - If a row exists with a lesser role → promotes to super-admin.
+ *   - Otherwise → inserts a fresh row with an audit log entry.
+ */
+export const _upsertSuperAdmin = internalMutation({
+  args: {
+    workosId: v.string(),
+    email: v.string(),
+    first_name: v.string(),
+    last_name: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query(TABLE_NAMES.ADMIN_USERS)
+      .withIndex("by_workos_id", (q) => q.eq("workosId", args.workosId))
+      .unique();
+
+    if (existing) {
+      if (existing.role === AdminRole.SUPER_ADMIN) {
+        console.log(
+          `Super-admin already exists for ${args.email} — nothing to do.`,
+        );
+      } else {
+        await ctx.db.patch(existing._id, { role: AdminRole.SUPER_ADMIN });
+        console.log(
+          `Promoted existing admin ${args.email} from "${existing.role}" to super-admin.`,
+        );
+      }
+      return null;
+    }
+
+    const now = Date.now();
+    const id = await ctx.db.insert(TABLE_NAMES.ADMIN_USERS, {
+      workosId: args.workosId,
+      email: args.email,
+      first_name: args.first_name,
+      last_name: args.last_name,
+      role: AdminRole.SUPER_ADMIN,
+      status: UserStatus.ACTIVE,
+      created_at: now,
+      last_login_at: null,
+    });
+
+    await auditLog.log(ctx, {
+      action: "admin_user.seeded",
+      resourceType: RESOURCE_TYPE.ADMIN_USER,
+      resourceId: id,
+      severity: "warning",
+      metadata: { email: args.email, role: AdminRole.SUPER_ADMIN },
+    });
+
+    console.log(`Super-admin seeded for ${args.email} (id: ${String(id)}).`);
+    return null;
   },
 });

--- a/packages/backend/convex/init.ts
+++ b/packages/backend/convex/init.ts
@@ -152,14 +152,19 @@ export const _upsertSuperAdmin = internalMutation({
       .unique();
 
     if (existing) {
-      if (existing.role === AdminRole.SUPER_ADMIN) {
+      if (existing.role === AdminRole.SUPER_ADMIN && existing.status === UserStatus.ACTIVE && existing.deleted_at === undefined) {
         console.log(
-          `Super-admin already exists for ${args.email} — nothing to do.`,
+          `Super-admin already active for workosId=${existing.workosId} — nothing to do.`,
         );
       } else {
-        await ctx.db.patch(existing._id, { role: AdminRole.SUPER_ADMIN });
+        // Promote role and reactivate if suspended/soft-deleted.
+        await ctx.db.patch(existing._id, {
+          role: AdminRole.SUPER_ADMIN,
+          status: UserStatus.ACTIVE,
+          deleted_at: undefined,
+        });
         console.log(
-          `Promoted existing admin ${args.email} from "${existing.role}" to super-admin.`,
+          `Promoted/reactivated admin workosId=${existing.workosId} to super-admin (was role="${existing.role}", status="${existing.status}").`,
         );
       }
       return null;
@@ -185,7 +190,7 @@ export const _upsertSuperAdmin = internalMutation({
       metadata: { email: args.email, role: AdminRole.SUPER_ADMIN },
     });
 
-    console.log(`Super-admin seeded for ${args.email} (id: ${String(id)}).`);
+    console.log(`Super-admin seeded: id=${String(id)}, workosId=${args.workosId}.`);
     return null;
   },
 });

--- a/packages/backend/convex/init.ts
+++ b/packages/backend/convex/init.ts
@@ -163,6 +163,17 @@ export const _upsertSuperAdmin = internalMutation({
           status: UserStatus.ACTIVE,
           deleted_at: undefined,
         });
+        await auditLog.log(ctx, {
+          action: "admin_user.promoted_to_super_admin",
+          resourceType: RESOURCE_TYPE.ADMIN_USER,
+          resourceId: existing._id,
+          severity: "warning",
+          metadata: {
+            workos_id: existing.workosId,
+            previous_role: existing.role,
+            previous_status: existing.status,
+          },
+        });
         console.log(
           `Promoted/reactivated admin workosId=${existing.workosId} to super-admin (was role="${existing.role}", status="${existing.status}").`,
         );


### PR DESCRIPTION
## Summary

- Adds `seedSuperAdmin` idempotent internal action to `init.ts` for bootstrapping the first super-admin from the CLI without a running UI
- Adds `_upsertSuperAdmin` internal mutation: upserts the admin row (promotes if already exists at a lesser role, no-ops if already active super-admin)
- Promotion path also reactivates suspended/soft-deleted rows (`status → ACTIVE`, `deleted_at` cleared)
- Console logs use `workosId` instead of email to avoid logging PII
- Fixes `adminViewerValidator` to include `_creationTime` field
- Replaces deprecated `.toThrowError()` with `.toThrow()` in policy guard tests

## Usage

```bash
# Set the env var once
npx convex env set SUPER_ADMIN_EMAIL you@example.com

# Run the bootstrap (idempotent — safe to re-run)
npx convex run init:seedSuperAdmin
```

**Prerequisites:** A WorkOS user with that email must already exist (sign up via the app or create manually in the WorkOS dashboard). `WORKOS_API_KEY` must also be set.

## Test plan

- [ ] `pnpm -F backend test` → 47/47 pass
- [ ] `pnpm -F backend exec tsc --noEmit -p convex` → exit 0
- [ ] Manual: set `SUPER_ADMIN_EMAIL`, run `npx convex run init:seedSuperAdmin` → row appears in `admin_users` with `role: "super-admin"`, `status: "active"`
- [ ] Re-run → logs "already active — nothing to do" (no DB write)
- [ ] Run with existing lesser-role admin → promotes to super-admin and reactivates if suspended
- [ ] Run with suspended super-admin → reactivates row
- [ ] Verify console output contains workosId, not email

## Review feedback addressed

- **Copilot** — Audit log when promoting an existing admin to super-admin: **fixed**. `_upsertSuperAdmin` now emits an `admin_user.promoted_to_super_admin` warning-severity audit log on the promotion / reactivation branch (commit `8ae9812`).
- **CodeRabbit** — Reactivate suspended / soft-deleted rows on promotion: **already addressed** in earlier commit `f042213` (patch sets `status: ACTIVE`, clears `deleted_at`).
- **CodeRabbit** — Avoid logging raw email PII: **already addressed** — logs use `existing.workosId` / `args.workosId`.
