### PR TITLE
feat(auth): revoke WorkOS membership on deactivate / reactivate

### DIFF
--- a/apps/web/src/routes/_protected/admin/team.tsx
+++ b/apps/web/src/routes/_protected/admin/team.tsx
@@ -78,7 +78,7 @@ function AdminTeamPage() {
 
   const isSuperAdmin = viewerQuery.data?.role === "super-admin";
 
-  // Redirect non-super_admins back to /admin.
+  // Redirect non-super-admins back to /admin.
   useEffect(() => {
     if (viewerQuery.isLoading) {
       return;
@@ -122,8 +122,6 @@ function AdminTeamPage() {
   }, [selected?._id, selected?.role]);
 
   const updateRole = useMutation(api.admin.updateAdminUserRole);
-  const deactivate = useMutation(api.admin.deactivateAdminUser);
-  const reactivate = useMutation(api.admin.reactivateAdminUser);
 
   const refresh = async () => {
     await queryClient.invalidateQueries({ queryKey: listOptions.queryKey });
@@ -205,7 +203,7 @@ function AdminTeamPage() {
 
     try {
       setPendingAction("deactivate");
-      await deactivate({ id: selected._id });
+      await convex.action(api.admin.deactivateAdminUser, { id: selected._id });
       toast.success("Admin user deactivated.");
       await refresh();
     } catch (error) {
@@ -221,7 +219,7 @@ function AdminTeamPage() {
     if (!selected) return;
     try {
       setPendingAction("reactivate");
-      await reactivate({ id: selected._id });
+      await convex.action(api.admin.reactivateAdminUser, { id: selected._id });
       toast.success("Admin user reactivated.");
       await refresh();
     } catch (error) {

--- a/packages/backend/convex/admin.ts
+++ b/packages/backend/convex/admin.ts
@@ -811,7 +811,11 @@ interface WorkOSMembership {
 
 /**
  * Look up a WorkOS OrganizationMembership for a given user in a given org.
- * Returns the membership object or null if not found (invite still pending).
+ * Returns the membership object, or null when the API succeeds with an empty
+ * result (no membership yet — invite still pending).
+ *
+ * Throws ConvexError on network failure, timeout, or non-2xx response so the
+ * caller can roll back local writes instead of silently skipping WorkOS sync.
  */
 async function findWorkOSMembership(
   workosUserId: string,
@@ -819,13 +823,20 @@ async function findWorkOSMembership(
   apiKey: string,
 ): Promise<WorkOSMembership | null> {
   const url = `https://api.workos.com/user_management/organization_memberships?user_id=${encodeURIComponent(workosUserId)}&organization_id=${encodeURIComponent(organizationId)}`;
-  const resp = await fetch(url, {
-    method: "GET",
-    headers: { Authorization: `Bearer ${apiKey}` },
-    signal: AbortSignal.timeout(WORKOS_TIMEOUT_MS),
-  }).catch(() => null);
-
-  if (!resp || !resp.ok) return null;
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(WORKOS_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      throw new ConvexError("WorkOS membership lookup timed out");
+    }
+    throw new ConvexError("WorkOS membership lookup request failed");
+  }
+  if (!resp.ok) throw new ConvexError(safeWorkOSError(resp.status));
 
   const body = (await resp.json()) as { data?: WorkOSMembership[] };
   return body.data?.[0] ?? null;
@@ -904,34 +915,36 @@ export const deactivateAdminUser = action({
         viewerId: viewer._id,
       });
 
-    // 2. Sync WorkOS membership.
-    const membership = await findWorkOSMembership(
-      target.workosId,
-      organizationId,
-      apiKey,
-    );
-    if (membership) {
-      try {
+    // 2. Sync WorkOS membership. Wraps both lookup and status flip so a lookup
+    //    failure (timeout / non-2xx) also triggers rollback instead of silently
+    //    skipping the WorkOS sync.
+    try {
+      const membership = await findWorkOSMembership(
+        target.workosId,
+        organizationId,
+        apiKey,
+      );
+      if (membership) {
         await setWorkOSMembershipStatus(membership.id, "deactivate", apiKey);
-      } catch (err) {
-        // Rollback local write so state stays consistent.
-        await ctx.runMutation(internal.admin._reactivateAdminUserLocal, {
-          id: args.id,
-          viewerId: viewer._id,
-        });
-        await auditLog.log(ctx, {
-          action: "admin_user.deactivate.workos_failed",
-          actorId: viewer._id,
-          resourceType: RESOURCE_TYPE.ADMIN_USER,
-          resourceId: args.id,
-          severity: "critical",
-          metadata: {
-            target_admin_user_id: args.id,
-            error: err instanceof Error ? err.message : String(err),
-          },
-        });
-        throw err;
       }
+    } catch (err) {
+      // Rollback local write so state stays consistent.
+      await ctx.runMutation(internal.admin._reactivateAdminUserLocal, {
+        id: args.id,
+        viewerId: viewer._id,
+      });
+      await auditLog.log(ctx, {
+        action: "admin_user.deactivate.workos_failed",
+        actorId: viewer._id,
+        resourceType: RESOURCE_TYPE.ADMIN_USER,
+        resourceId: args.id,
+        severity: "critical",
+        metadata: {
+          target_admin_user_id: args.id,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
+      throw err;
     }
 
     return updated;
@@ -965,6 +978,13 @@ export const reactivateAdminUser = action({
       });
     if (!target) throw new ConvexError("Admin user not found");
 
+    // Capture pre-state so rollback is only applied when the local mutation
+    // actually changed something. _reactivateAdminUserLocal is a no-op when
+    // the target is already ACTIVE — rolling back in that case would wrongly
+    // deactivate an already-active admin.
+    const wasSuspended =
+      target.status !== UserStatus.ACTIVE || target.deleted_at !== undefined;
+
     // 1. Local write first.
     const updated: Infer<typeof adminUserRecordValidator> =
       await ctx.runMutation(internal.admin._reactivateAdminUserLocal, {
@@ -972,34 +992,38 @@ export const reactivateAdminUser = action({
         viewerId: viewer._id,
       });
 
-    // 2. Sync WorkOS membership.
-    const membership = await findWorkOSMembership(
-      target.workosId,
-      organizationId,
-      apiKey,
-    );
-    if (membership) {
-      try {
+    // 2. Sync WorkOS membership. Wraps both lookup and status flip so a lookup
+    //    failure (timeout / non-2xx) also triggers rollback.
+    try {
+      const membership = await findWorkOSMembership(
+        target.workosId,
+        organizationId,
+        apiKey,
+      );
+      if (membership) {
         await setWorkOSMembershipStatus(membership.id, "reactivate", apiKey);
-      } catch (err) {
-        // Rollback local write.
+      }
+    } catch (err) {
+      if (wasSuspended) {
+        // Only rollback if the local write actually changed state.
         await ctx.runMutation(internal.admin._deactivateAdminUserLocal, {
           id: args.id,
           viewerId: viewer._id,
         });
-        await auditLog.log(ctx, {
-          action: "admin_user.reactivate.workos_failed",
-          actorId: viewer._id,
-          resourceType: RESOURCE_TYPE.ADMIN_USER,
-          resourceId: args.id,
-          severity: "critical",
-          metadata: {
-            target_admin_user_id: args.id,
-            error: err instanceof Error ? err.message : String(err),
-          },
-        });
-        throw err;
       }
+      await auditLog.log(ctx, {
+        action: "admin_user.reactivate.workos_failed",
+        actorId: viewer._id,
+        resourceType: RESOURCE_TYPE.ADMIN_USER,
+        resourceId: args.id,
+        severity: "critical",
+        metadata: {
+          target_admin_user_id: args.id,
+          was_suspended: wasSuspended,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
+      throw err;
     }
 
     return updated;

--- a/packages/backend/convex/admin.ts
+++ b/packages/backend/convex/admin.ts
@@ -389,7 +389,9 @@ export const _deactivateAdminUserLocal = internalMutation({
   returns: adminUserRecordValidator,
   handler: async (ctx, args) => {
     const viewer = await ctx.db.get(args.viewerId);
-    if (!viewer) throw new ConvexError("Not authorized");
+    if (!viewer || viewer.role !== AdminRole.SUPER_ADMIN || viewer.status !== UserStatus.ACTIVE) {
+      throw new ConvexError("Not authorized");
+    }
 
     const target = await ctx.db.get(args.id);
     if (!target) {
@@ -445,7 +447,9 @@ export const _reactivateAdminUserLocal = internalMutation({
   returns: adminUserRecordValidator,
   handler: async (ctx, args) => {
     const viewer = await ctx.db.get(args.viewerId);
-    if (!viewer) throw new ConvexError("Not authorized");
+    if (!viewer || viewer.role !== AdminRole.SUPER_ADMIN || viewer.status !== UserStatus.ACTIVE) {
+      throw new ConvexError("Not authorized");
+    }
 
     const target = await ctx.db.get(args.id);
     if (!target) {

--- a/packages/backend/convex/admin.ts
+++ b/packages/backend/convex/admin.ts
@@ -1,4 +1,4 @@
-import { ConvexError, v } from "convex/values";
+import { ConvexError, v, type Infer } from "convex/values";
 
 import type { MutationCtx } from "./_generated/server";
 import type { AdminUserId } from "./types";
@@ -371,22 +371,25 @@ export const updateAdminUserRole = mutation({
 });
 
 /**
- * Deactivate (soft-delete) an admin user.
+ * Internal mutation: deactivate (soft-delete) an admin user.
+ * Called only from the deactivateAdminUser action.
  *
  * Guards:
  *  - caller must be super-admin
  *  - cannot deactivate self
  *  - cannot deactivate the last active super-admin
  *
- * Sets `deleted_at` and `status = "suspended"`. Does not touch WorkOS.
- *
- * SECURITY: super-admin only.
+ * Sets `deleted_at` and `status = "suspended"`.
  */
-export const deactivateAdminUser = mutation({
-  args: { id: v.id("admin_users") },
+export const _deactivateAdminUserLocal = internalMutation({
+  args: {
+    id: v.id("admin_users"),
+    viewerId: v.id("admin_users"),
+  },
   returns: adminUserRecordValidator,
   handler: async (ctx, args) => {
-    const viewer = await assertSuperAdmin(ctx);
+    const viewer = await ctx.db.get(args.viewerId);
+    if (!viewer) throw new ConvexError("Not authorized");
 
     const target = await ctx.db.get(args.id);
     if (!target) {
@@ -429,16 +432,20 @@ export const deactivateAdminUser = mutation({
 });
 
 /**
- * Reactivate a previously deactivated admin user.
- * Clears `deleted_at` and sets `status = "active"`.
+ * Internal mutation: reactivate a previously deactivated admin user.
+ * Called only from the reactivateAdminUser action.
  *
- * SECURITY: super-admin only.
+ * Clears `deleted_at` and sets `status = "active"`.
  */
-export const reactivateAdminUser = mutation({
-  args: { id: v.id("admin_users") },
+export const _reactivateAdminUserLocal = internalMutation({
+  args: {
+    id: v.id("admin_users"),
+    viewerId: v.id("admin_users"),
+  },
   returns: adminUserRecordValidator,
   handler: async (ctx, args) => {
-    const viewer = await assertSuperAdmin(ctx);
+    const viewer = await ctx.db.get(args.viewerId);
+    if (!viewer) throw new ConvexError("Not authorized");
 
     const target = await ctx.db.get(args.id);
     if (!target) {
@@ -766,13 +773,231 @@ export const inviteAdminUser = action({
 });
 
 /**
- * Internal helper for the inviteAdminUser action.
- * Returns the calling admin's record (super_admin only).
+ * Internal helper for actions that require a super-admin caller.
+ * Returns the calling admin's record (super-admin only).
  */
 export const _viewerForAction = internalQuery({
   args: {},
   returns: adminUserRecordValidator,
   handler: async (ctx) => {
     return await assertSuperAdmin(ctx);
+  },
+});
+
+/**
+ * Internal query: fetch a target admin user by ID for use inside actions.
+ * Returns the full record so actions can read workosId, role, status, deleted_at.
+ */
+export const _getAdminUserForAction = internalQuery({
+  args: { id: v.id("admin_users") },
+  returns: v.union(adminUserRecordValidator, v.null()),
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// WorkOS membership helpers (used by deactivate / reactivate / role-change actions)
+// ---------------------------------------------------------------------------
+
+interface WorkOSMembership {
+  id: string;
+  status: string;
+}
+
+/**
+ * Look up a WorkOS OrganizationMembership for a given user in a given org.
+ * Returns the membership object or null if not found (invite still pending).
+ */
+async function findWorkOSMembership(
+  workosUserId: string,
+  organizationId: string,
+  apiKey: string,
+): Promise<WorkOSMembership | null> {
+  const url = `https://api.workos.com/user_management/organization_memberships?user_id=${encodeURIComponent(workosUserId)}&organization_id=${encodeURIComponent(organizationId)}`;
+  const resp = await fetch(url, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(WORKOS_TIMEOUT_MS),
+  }).catch(() => null);
+
+  if (!resp || !resp.ok) return null;
+
+  const body = (await resp.json()) as { data?: WorkOSMembership[] };
+  return body.data?.[0] ?? null;
+}
+
+/**
+ * Flip the status of a WorkOS OrganizationMembership.
+ * action: "deactivate" | "reactivate"
+ */
+async function setWorkOSMembershipStatus(
+  membershipId: string,
+  action: "deactivate" | "reactivate",
+  apiKey: string,
+): Promise<void> {
+  const url = `https://api.workos.com/user_management/organization_memberships/${encodeURIComponent(membershipId)}/${action}`;
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      signal: AbortSignal.timeout(WORKOS_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      throw new ConvexError(`WorkOS membership ${action} timed out`);
+    }
+    throw new ConvexError(`WorkOS membership ${action} request failed`);
+  }
+  if (!resp.ok) {
+    throw new ConvexError(safeWorkOSError(resp.status));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public actions: deactivate / reactivate (local-first + WorkOS sync + rollback)
+// ---------------------------------------------------------------------------
+
+/**
+ * Deactivate an admin user.
+ *
+ * Writes locally first (guards run, row suspended), then deactivates the
+ * WorkOS OrganizationMembership. On WorkOS failure the local write is rolled
+ * back so the two systems stay in sync.
+ *
+ * If the invite was never accepted (no membership found), WorkOS step is
+ * skipped — the admin never had WorkOS access anyway.
+ *
+ * SECURITY: super-admin only.
+ */
+export const deactivateAdminUser = action({
+  args: { id: v.id("admin_users") },
+  returns: adminUserRecordValidator,
+  handler: async (ctx, args) => {
+    const viewer: Infer<typeof adminUserRecordValidator> =
+      await ctx.runQuery(internal.admin._viewerForAction, {});
+
+    const apiKey = process.env.WORKOS_API_KEY;
+    if (!apiKey) throw new ConvexError("WORKOS_API_KEY is not configured");
+    const organizationId = process.env.WORKOS_ADMIN_ORG_ID;
+    if (!organizationId)
+      throw new ConvexError("WORKOS_ADMIN_ORG_ID is not configured");
+
+    const target: Infer<typeof adminUserRecordValidator> | null =
+      await ctx.runQuery(internal.admin._getAdminUserForAction, {
+        id: args.id,
+      });
+    if (!target) throw new ConvexError("Admin user not found");
+
+    // 1. Local write first — guards run here.
+    const updated: Infer<typeof adminUserRecordValidator> =
+      await ctx.runMutation(internal.admin._deactivateAdminUserLocal, {
+        id: args.id,
+        viewerId: viewer._id,
+      });
+
+    // 2. Sync WorkOS membership.
+    const membership = await findWorkOSMembership(
+      target.workosId,
+      organizationId,
+      apiKey,
+    );
+    if (membership) {
+      try {
+        await setWorkOSMembershipStatus(membership.id, "deactivate", apiKey);
+      } catch (err) {
+        // Rollback local write so state stays consistent.
+        await ctx.runMutation(internal.admin._reactivateAdminUserLocal, {
+          id: args.id,
+          viewerId: viewer._id,
+        });
+        await auditLog.log(ctx, {
+          action: "admin_user.deactivate.workos_failed",
+          actorId: viewer._id,
+          resourceType: RESOURCE_TYPE.ADMIN_USER,
+          resourceId: args.id,
+          severity: "critical",
+          metadata: {
+            target_admin_user_id: args.id,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+        throw err;
+      }
+    }
+
+    return updated;
+  },
+});
+
+/**
+ * Reactivate a previously deactivated admin user.
+ *
+ * Writes locally first, then reactivates the WorkOS OrganizationMembership.
+ * On WorkOS failure the local write is rolled back.
+ *
+ * SECURITY: super-admin only.
+ */
+export const reactivateAdminUser = action({
+  args: { id: v.id("admin_users") },
+  returns: adminUserRecordValidator,
+  handler: async (ctx, args) => {
+    const viewer: Infer<typeof adminUserRecordValidator> =
+      await ctx.runQuery(internal.admin._viewerForAction, {});
+
+    const apiKey = process.env.WORKOS_API_KEY;
+    if (!apiKey) throw new ConvexError("WORKOS_API_KEY is not configured");
+    const organizationId = process.env.WORKOS_ADMIN_ORG_ID;
+    if (!organizationId)
+      throw new ConvexError("WORKOS_ADMIN_ORG_ID is not configured");
+
+    const target: Infer<typeof adminUserRecordValidator> | null =
+      await ctx.runQuery(internal.admin._getAdminUserForAction, {
+        id: args.id,
+      });
+    if (!target) throw new ConvexError("Admin user not found");
+
+    // 1. Local write first.
+    const updated: Infer<typeof adminUserRecordValidator> =
+      await ctx.runMutation(internal.admin._reactivateAdminUserLocal, {
+        id: args.id,
+        viewerId: viewer._id,
+      });
+
+    // 2. Sync WorkOS membership.
+    const membership = await findWorkOSMembership(
+      target.workosId,
+      organizationId,
+      apiKey,
+    );
+    if (membership) {
+      try {
+        await setWorkOSMembershipStatus(membership.id, "reactivate", apiKey);
+      } catch (err) {
+        // Rollback local write.
+        await ctx.runMutation(internal.admin._deactivateAdminUserLocal, {
+          id: args.id,
+          viewerId: viewer._id,
+        });
+        await auditLog.log(ctx, {
+          action: "admin_user.reactivate.workos_failed",
+          actorId: viewer._id,
+          resourceType: RESOURCE_TYPE.ADMIN_USER,
+          resourceId: args.id,
+          severity: "critical",
+          metadata: {
+            target_admin_user_id: args.id,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+        throw err;
+      }
+    }
+
+    return updated;
   },
 });


### PR DESCRIPTION
## Summary

- Converts `deactivateAdminUser` and `reactivateAdminUser` from public mutations to internal mutations + public actions
- Each action runs the local DB write first (all guards enforced), then syncs the WorkOS `OrganizationMembership` status via `PUT /deactivate` or `PUT /reactivate`
- On WorkOS failure the local write is rolled back so both systems stay in sync
- If the invite was never accepted (no membership found), the WorkOS step is skipped
- Internal mutations validate viewer is an active super-admin (role + status check), not just that the record exists
- Frontend updated to call `convex.action()` instead of `useMutation()` for deactivate and reactivate

## New additions

| Symbol | Type | Purpose |
|---|---|---|
| `_deactivateAdminUserLocal` | internal mutation | DB write + audit log; validates viewer is active super-admin |
| `_reactivateAdminUserLocal` | internal mutation | DB write + audit log; validates viewer is active super-admin |
| `_getAdminUserForAction` | internal query | Fetch target admin record inside an action |
| `findWorkOSMembership` | helper | `GET /organization_memberships?user_id=&organization_id=` |
| `setWorkOSMembershipStatus` | helper | `PUT …/deactivate` or `PUT …/reactivate` |
| `deactivateAdminUser` | public action | Orchestrates local write + WorkOS sync + rollback |
| `reactivateAdminUser` | public action | Orchestrates local write + WorkOS sync + rollback |

## Known limitations

- If an invitation is still pending (no membership created yet), deactivate/reactivate leaves the invitation alive. Cleaning up pending invitations is a separate ticket.
- There is a brief window between a successful local write and a failed WorkOS call where the admin still has WorkOS access. The rollback re-activates locally. WorkOS access alone does not grant Convex access (separate JWT subject lookup).

## Test plan

- [ ] `pnpm -F backend test` → 47/47 pass
- [ ] `pnpm -F backend exec tsc --noEmit -p convex` → exit 0
- [ ] `pnpm -F web exec tsc --noEmit` → exit 0
- [ ] Manual: invite + accept, deactivate → WorkOS dashboard shows membership `inactive`, local row `suspended` with `deleted_at` set
- [ ] Manual: reactivate → WorkOS membership flips back to `active`, local row `active`
- [ ] Manual: deactivate admin who never accepted invite → succeeds locally, no WorkOS error
- [ ] Manual: simulate WorkOS failure (bad API key) → UI shows error, local row rolls back

## Review feedback addressed

- **Copilot** — `findWorkOSMembership` silently returns `null` on fetch failure / non-2xx, hiding outages and skipping rollback: **fixed**. Helper now throws `ConvexError` on network failure / timeout / non-2xx; only returns `null` when the API succeeds with an empty result. Both `deactivateAdminUser` and `reactivateAdminUser` wrap the lookup inside the same try/catch as the status flip so a lookup failure also triggers rollback + critical audit log (commit `879d7a9`).
- **Copilot** — `reactivateAdminUser` rollback always calls `_deactivateAdminUserLocal` even when the local mutation was a no-op (target already active): **fixed**. Action now captures `wasSuspended` pre-state and only rolls back when the local write actually changed state, preventing a WorkOS failure from wrongly deactivating an already-active admin (commit `879d7a9`).
