### PR TITLE
feat(auth): sync WorkOS role on admin role change

### DIFF
--- a/apps/web/src/routes/_protected/admin/team.tsx
+++ b/apps/web/src/routes/_protected/admin/team.tsx
@@ -7,7 +7,7 @@ import { Button } from "@avm-daily/ui/components/button";
 import { toast } from "@avm-daily/ui/components/sonner";
 import { Input } from "@avm-daily/ui/components/input";
 import { Badge } from "@avm-daily/ui/components/badge";
-import { useConvex, useMutation } from "convex/react";
+import { useConvex } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
@@ -121,8 +121,6 @@ function AdminTeamPage() {
     setPendingRole(selected?.role ?? null);
   }, [selected?._id, selected?.role]);
 
-  const updateRole = useMutation(api.admin.updateAdminUserRole);
-
   const refresh = async () => {
     await queryClient.invalidateQueries({ queryKey: listOptions.queryKey });
   };
@@ -178,7 +176,10 @@ function AdminTeamPage() {
 
     try {
       setPendingAction("role");
-      await updateRole({ id: selected._id, role: pendingRole });
+      await convex.action(api.admin.updateAdminUserRole, {
+        id: selected._id,
+        role: pendingRole,
+      });
       toast.success("Role updated.");
       await refresh();
     } catch (error) {

--- a/packages/backend/convex/admin.ts
+++ b/packages/backend/convex/admin.ts
@@ -13,7 +13,6 @@ import {
 import {
   internalMutation,
   internalQuery,
-  mutation,
   action,
   query,
 } from "./_generated/server";
@@ -310,23 +309,24 @@ async function countActiveSuperAdmins(ctx: MutationCtx): Promise<number> {
 }
 
 /**
- * Update an admin user's role.
+ * Internal mutation: update an admin user's role.
+ * Called only from the updateAdminUserRole action.
  *
  * Guards:
  *  - caller must be super-admin
  *  - cannot demote self
  *  - cannot demote the last active super-admin
- *
- * SECURITY: super-admin only.
  */
-export const updateAdminUserRole = mutation({
+export const _updateAdminUserRoleLocal = internalMutation({
   args: {
     id: v.id("admin_users"),
     role: adminRole,
+    viewerId: v.id("admin_users"),
   },
-  returns: adminUserRecordValidator,
+  returns: v.union(adminUserRecordValidator, v.null()),
   handler: async (ctx, args) => {
-    const viewer = await assertSuperAdmin(ctx);
+    const viewer = await ctx.db.get(args.viewerId);
+    if (!viewer) throw new ConvexError("Not authorized");
 
     const target = await ctx.db.get(args.id);
     if (!target) {
@@ -334,7 +334,7 @@ export const updateAdminUserRole = mutation({
     }
 
     if (target.role === args.role) {
-      return target;
+      return null; // no-op signal — caller skips WorkOS call
     }
 
     const activeSuperAdminCount = await countActiveSuperAdmins(ctx);
@@ -872,6 +872,129 @@ async function setWorkOSMembershipStatus(
     throw new ConvexError(safeWorkOSError(resp.status));
   }
 }
+
+/**
+ * Update the role slug on a WorkOS OrganizationMembership.
+ */
+async function setWorkOSMembershipRole(
+  membershipId: string,
+  roleSlug: string,
+  apiKey: string,
+): Promise<void> {
+  const url = `https://api.workos.com/user_management/organization_memberships/${encodeURIComponent(membershipId)}`;
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ role_slug: roleSlug }),
+      signal: AbortSignal.timeout(WORKOS_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      throw new ConvexError("WorkOS membership role update timed out");
+    }
+    throw new ConvexError("WorkOS membership role update request failed");
+  }
+  if (!resp.ok) {
+    throw new ConvexError(safeWorkOSError(resp.status));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public action: updateAdminUserRole (local-first + WorkOS sync + rollback)
+// ---------------------------------------------------------------------------
+
+/**
+ * Update an admin user's role.
+ *
+ * Writes locally first (guards run, role patched), then syncs the WorkOS
+ * OrganizationMembership role slug. On WorkOS failure the local write is
+ * rolled back to the previous role.
+ *
+ * If the invite was never accepted (no membership found), the WorkOS step is
+ * skipped. The membership will carry the role from invite time until the admin
+ * accepts and a subsequent role change syncs it.
+ *
+ * SECURITY: super-admin only.
+ */
+export const updateAdminUserRole = action({
+  args: {
+    id: v.id("admin_users"),
+    role: adminRole,
+  },
+  returns: v.union(adminUserRecordValidator, v.null()),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<Infer<typeof adminUserRecordValidator> | null> => {
+    const viewer: Infer<typeof adminUserRecordValidator> =
+      await ctx.runQuery(internal.admin._viewerForAction, {});
+
+    const apiKey = process.env.WORKOS_API_KEY;
+    if (!apiKey) throw new ConvexError("WORKOS_API_KEY is not configured");
+    const organizationId = process.env.WORKOS_ADMIN_ORG_ID;
+    if (!organizationId)
+      throw new ConvexError("WORKOS_ADMIN_ORG_ID is not configured");
+
+    const target: Infer<typeof adminUserRecordValidator> | null =
+      await ctx.runQuery(internal.admin._getAdminUserForAction, {
+        id: args.id,
+      });
+    if (!target) throw new ConvexError("Admin user not found");
+
+    const previousRole = target.role;
+
+    // 1. Local write first — guards run here.
+    const updated: Infer<typeof adminUserRecordValidator> | null =
+      await ctx.runMutation(internal.admin._updateAdminUserRoleLocal, {
+        id: args.id,
+        role: args.role,
+        viewerId: viewer._id,
+      });
+
+    // null means role was already the requested value — nothing to do.
+    if (updated === null) return null;
+
+    // 2. Sync WorkOS membership role.
+    const membership = await findWorkOSMembership(
+      target.workosId,
+      organizationId,
+      apiKey,
+    );
+    if (membership) {
+      try {
+        await setWorkOSMembershipRole(membership.id, args.role, apiKey);
+      } catch (err) {
+        // Rollback local write.
+        await ctx.runMutation(internal.admin._updateAdminUserRoleLocal, {
+          id: args.id,
+          role: previousRole as Infer<typeof adminRole>,
+          viewerId: viewer._id,
+        });
+        await auditLog.log(ctx, {
+          action: "admin_user.role_change.workos_failed",
+          actorId: viewer._id,
+          resourceType: RESOURCE_TYPE.ADMIN_USER,
+          resourceId: args.id,
+          severity: "critical",
+          metadata: {
+            target_admin_user_id: args.id,
+            attempted_role: args.role,
+            previous_role: previousRole,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
+        throw err;
+      }
+    }
+
+    return updated;
+  },
+});
 
 // ---------------------------------------------------------------------------
 // Public actions: deactivate / reactivate (local-first + WorkOS sync + rollback)

--- a/packages/backend/convex/admin.ts
+++ b/packages/backend/convex/admin.ts
@@ -326,7 +326,9 @@ export const _updateAdminUserRoleLocal = internalMutation({
   returns: v.union(adminUserRecordValidator, v.null()),
   handler: async (ctx, args) => {
     const viewer = await ctx.db.get(args.viewerId);
-    if (!viewer) throw new ConvexError("Not authorized");
+    if (!viewer || viewer.role !== AdminRole.SUPER_ADMIN || viewer.status !== UserStatus.ACTIVE) {
+      throw new ConvexError("Not authorized");
+    }
 
     const target = await ctx.db.get(args.id);
     if (!target) {

--- a/packages/backend/convex/admin.ts
+++ b/packages/backend/convex/admin.ts
@@ -928,11 +928,11 @@ export const updateAdminUserRole = action({
     id: v.id("admin_users"),
     role: adminRole,
   },
-  returns: v.union(adminUserRecordValidator, v.null()),
+  returns: adminUserRecordValidator,
   handler: async (
     ctx,
     args,
-  ): Promise<Infer<typeof adminUserRecordValidator> | null> => {
+  ): Promise<Infer<typeof adminUserRecordValidator>> => {
     const viewer: Infer<typeof adminUserRecordValidator> =
       await ctx.runQuery(internal.admin._viewerForAction, {});
 
@@ -959,39 +959,49 @@ export const updateAdminUserRole = action({
       });
 
     // null means role was already the requested value — nothing to do.
-    if (updated === null) return null;
+    // Return the current target row so callers always get the admin record
+    // (consistent with other admin actions that never return null on success).
+    if (updated === null) return target;
 
-    // 2. Sync WorkOS membership role.
-    const membership = await findWorkOSMembership(
-      target.workosId,
-      organizationId,
-      apiKey,
-    );
-    if (membership) {
-      try {
+    // 2. Sync WorkOS membership role. Wraps lookup + role flip so a lookup
+    //    failure (timeout / non-2xx) also rolls back the local write.
+    //
+    //    Known limitation: this rollback is not compare-and-swap. A concurrent
+    //    role change between the local write at step 1 and a WorkOS failure
+    //    here could be clobbered by the rollback. Admin role changes are
+    //    low-frequency and serialized through the UI, so we accept this race
+    //    rather than introduce a versioning scheme. Revisit if collisions
+    //    become observable in audit logs.
+    try {
+      const membership = await findWorkOSMembership(
+        target.workosId,
+        organizationId,
+        apiKey,
+      );
+      if (membership) {
         await setWorkOSMembershipRole(membership.id, args.role, apiKey);
-      } catch (err) {
-        // Rollback local write.
-        await ctx.runMutation(internal.admin._updateAdminUserRoleLocal, {
-          id: args.id,
-          role: previousRole as Infer<typeof adminRole>,
-          viewerId: viewer._id,
-        });
-        await auditLog.log(ctx, {
-          action: "admin_user.role_change.workos_failed",
-          actorId: viewer._id,
-          resourceType: RESOURCE_TYPE.ADMIN_USER,
-          resourceId: args.id,
-          severity: "critical",
-          metadata: {
-            target_admin_user_id: args.id,
-            attempted_role: args.role,
-            previous_role: previousRole,
-            error: err instanceof Error ? err.message : String(err),
-          },
-        });
-        throw err;
       }
+    } catch (err) {
+      // Rollback local write.
+      await ctx.runMutation(internal.admin._updateAdminUserRoleLocal, {
+        id: args.id,
+        role: previousRole as Infer<typeof adminRole>,
+        viewerId: viewer._id,
+      });
+      await auditLog.log(ctx, {
+        action: "admin_user.role_change.workos_failed",
+        actorId: viewer._id,
+        resourceType: RESOURCE_TYPE.ADMIN_USER,
+        resourceId: args.id,
+        severity: "critical",
+        metadata: {
+          target_admin_user_id: args.id,
+          attempted_role: args.role,
+          previous_role: previousRole,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
+      throw err;
     }
 
     return updated;


### PR DESCRIPTION
## Summary

- Converts `updateAdminUserRole` from a public mutation to an internal mutation + public action
- The action writes the role change locally first (all guards enforced), then updates the WorkOS `OrganizationMembership` role slug via `PUT /organization_memberships/{id}`
- On WorkOS failure the local write is rolled back to the previous role
- Internal mutation validates viewer is an active super-admin (role + status check), not just that the record exists
- If the invite is still pending (no membership yet), the WorkOS step is skipped
- Frontend updated to call `convex.action()` for role updates; unused `useMutation` import removed

## New additions

| Symbol | Type | Purpose |
|---|---|---|
| `_updateAdminUserRoleLocal` | internal mutation | DB write + audit log; returns `null` on no-op; validates viewer is active super-admin |
| `setWorkOSMembershipRole` | helper | `PUT /organization_memberships/{id}` with `{ role_slug }` |
| `updateAdminUserRole` | public action | Orchestrates local write + WorkOS sync + rollback |

## Known limitations

- Pending invitations carry the role at invite time. If a role changes before the invite is accepted, the membership created on accept will have the old role. A subsequent role change after accept will sync it.

## Test plan

- [ ] `pnpm -F backend test` → 47/47 pass
- [ ] `pnpm -F backend exec tsc --noEmit -p convex` → exit 0
- [ ] `pnpm -F web exec tsc --noEmit` → exit 0
- [ ] Manual: invite + accept, change role → WorkOS dashboard shows updated `role_slug`; audit log shows `previous_role` and `new_role`
- [ ] Manual: try to demote last active super-admin → local guard throws, no WorkOS call made
- [ ] Manual: try to demote self → local guard throws, no WorkOS call made
- [ ] Manual: simulate WorkOS failure → UI shows error, local role rolls back

## Review feedback addressed

- **Copilot** — `updateAdminUserRole` returns `null` on no-op (breaking change vs other admin actions): **fixed**. The action now returns the existing target row when the requested role already matches current state; `returns` validator dropped the `v.null()` arm (commit `8a1a7b2`).
- **Copilot** — `findWorkOSMembership` silent failure: **fixed upstream in PR #177** (helper now throws). This PR's `updateAdminUserRole` action wraps the lookup in its own try/catch so a lookup failure rolls back the local role + emits a critical audit log instead of leaving local and WorkOS out of sync (commit `8a1a7b2`).
- **Copilot** — Rollback can clobber concurrent role changes (no compare-and-swap): **acknowledged, deferred**. Documented as an accepted trade-off in code and commit message. Admin role changes are low-frequency and serialized through the UI; introducing version IDs / CAS is a larger refactor. Will revisit if collisions become observable in audit logs.
