### PR TITLE
feat(observability): ship web server logs to axiom

### DIFF
--- a/apps/web/src/server/logging.ts
+++ b/apps/web/src/server/logging.ts
@@ -1,4 +1,5 @@
 import { createIsomorphicFn } from "@tanstack/react-start";
+import { Axiom } from "@axiomhq/js";
 
 export const LOG_LEVELS = {
   debug: "debug",
@@ -9,32 +10,35 @@ export const LOG_LEVELS = {
 
 export type LogLevel = (typeof LOG_LEVELS)[keyof typeof LOG_LEVELS];
 
+let _axiom: Axiom | null = null;
+
+function getAxiom(): Axiom | null {
+  if (process.env.NODE_ENV !== "production") return null;
+  if (!process.env.AXIOM_TOKEN || !process.env.AXIOM_DATASET) return null;
+  return (_axiom ??= new Axiom({ token: process.env.AXIOM_TOKEN }));
+}
+
 export const logger = createIsomorphicFn()
   .server((level: LogLevel, event: string, data?: any) => {
     const timestamp = new Date().toISOString();
+    const entry = {
+      timestamp,
+      level,
+      event,
+      data,
+      service: "avm-daily-server-logs",
+      environment: process.env.NODE_ENV,
+    };
 
     if (process.env.NODE_ENV === "development") {
-      // Development: Detailed console logging
       console[level](`[${timestamp}] [${level.toUpperCase()}]`, event, data);
     } else {
-      // Production: Structured JSON logging
-      console.log(
-        JSON.stringify({
-          timestamp,
-          level,
-          event,
-          data,
-          service: "tanstack-start",
-          environment: process.env.NODE_ENV,
-        })
-      );
+      console.log(JSON.stringify(entry));
+      getAxiom()?.ingest(process.env.AXIOM_DATASET!, [entry]);
     }
   })
   .client((level: LogLevel, event: string, data?: any) => {
     if (process.env.NODE_ENV === "development") {
       console[level](`[CLIENT] [${level.toUpperCase()}]`, event, data);
-    } else {
-      // Production: Send to analytics service
-      // analytics.track('client_log', { level, event, data })
     }
   });

--- a/apps/web/src/server/logging.ts
+++ b/apps/web/src/server/logging.ts
@@ -12,10 +12,12 @@ export type LogLevel = (typeof LOG_LEVELS)[keyof typeof LOG_LEVELS];
 
 let _axiom: Axiom | null = null;
 
-function getAxiom(): Axiom | null {
+function getAxiom(): { client: Axiom; dataset: string } | null {
   if (process.env.NODE_ENV !== "production") return null;
-  if (!process.env.AXIOM_TOKEN || !process.env.AXIOM_DATASET) return null;
-  return (_axiom ??= new Axiom({ token: process.env.AXIOM_TOKEN }));
+  const token = process.env.AXIOM_TOKEN;
+  const dataset = process.env.AXIOM_DATASET;
+  if (!token || !dataset) return null;
+  return { client: (_axiom ??= new Axiom({ token })), dataset };
 }
 
 export const logger = createIsomorphicFn()
@@ -34,7 +36,8 @@ export const logger = createIsomorphicFn()
       console[level](`[${timestamp}] [${level.toUpperCase()}]`, event, data);
     } else {
       console.log(JSON.stringify(entry));
-      getAxiom()?.ingest(process.env.AXIOM_DATASET!, [entry]);
+      const ax = getAxiom();
+      ax?.client.ingest(ax.dataset, [entry]);
     }
   })
   .client((level: LogLevel, event: string, data?: any) => {


### PR DESCRIPTION
Extends existing createIsomorphicFn logger to ingest structured logs
to Axiom in production via lazy @axiomhq/js singleton. Dev behavior
unchanged (console logging).