### PR TITLE
feat(analytics): posthog provider and user identity — web

### DIFF
--- a/apps/web/src/components/posthog-identity.tsx
+++ b/apps/web/src/components/posthog-identity.tsx
@@ -1,0 +1,20 @@
+import { useAuth } from "@workos/authkit-tanstack-react-start/client";
+import { posthog } from "@/lib/posthog";
+import { useEffect } from "react";
+
+export function PostHogIdentity() {
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (!user) {
+      posthog.reset();
+      return;
+    }
+    posthog.identify(user.id, {
+      email: user.email,
+      name: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || undefined,
+    });
+  }, [user?.id]);
+
+  return null;
+}

--- a/apps/web/src/components/posthog-identity.tsx
+++ b/apps/web/src/components/posthog-identity.tsx
@@ -14,7 +14,7 @@ export function PostHogIdentity() {
       email: user.email,
       name: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || undefined,
     });
-  }, [user?.id]);
+  }, [user]);
 
   return null;
 }

--- a/apps/web/src/components/posthog-provider.tsx
+++ b/apps/web/src/components/posthog-provider.tsx
@@ -1,0 +1,17 @@
+import { initPostHog, posthog } from "@/lib/posthog";
+import { useRouter } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    initPostHog();
+    const unsub = router.subscribe("onResolved", () => {
+      posthog.capture("$pageview", { $current_url: window.location.href });
+    });
+    return () => unsub();
+  }, [router]);
+
+  return <>{children}</>;
+}

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -5,17 +5,22 @@ let initialized = false;
 
 export function initPostHog() {
   if (typeof window === "undefined" || initialized) return;
-  initialized = true;
+  if (!env.VITE_POSTHOG_KEY) return;
 
-  posthog.init(env.VITE_POSTHOG_KEY, {
-    api_host: env.VITE_POSTHOG_HOST,
-    person_profiles: "identified_only",
-    capture_pageview: false,
-    capture_pageleave: true,
-    loaded: (ph) => {
-      if (import.meta.env.DEV) ph.opt_out_capturing();
-    },
-  });
+  try {
+    posthog.init(env.VITE_POSTHOG_KEY, {
+      api_host: env.VITE_POSTHOG_HOST,
+      person_profiles: "identified_only",
+      capture_pageview: false,
+      capture_pageleave: true,
+      loaded: (ph) => {
+        if (import.meta.env.DEV) ph.opt_out_capturing();
+      },
+    });
+    initialized = true;
+  } catch (e) {
+    console.error("[posthog] init failed", e);
+  }
 }
 
 export { posthog };

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -1,0 +1,21 @@
+import posthog from "posthog-js";
+import { env } from "@avm-daily/env/web";
+
+let initialized = false;
+
+export function initPostHog() {
+  if (typeof window === "undefined" || initialized) return;
+  initialized = true;
+
+  posthog.init(env.VITE_POSTHOG_KEY, {
+    api_host: env.VITE_POSTHOG_HOST,
+    person_profiles: "identified_only",
+    capture_pageview: false,
+    capture_pageleave: true,
+    loaded: (ph) => {
+      if (import.meta.env.DEV) ph.opt_out_capturing();
+    },
+  });
+}
+
+export { posthog };

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -18,6 +18,8 @@ import {
   Outlet,
 } from "@tanstack/react-router";
 
+import { PostHogProvider } from "@/components/posthog-provider";
+
 import appCss from "../index.css?url";
 
 export interface RouterAppContext {
@@ -84,7 +86,8 @@ function useAuthForConvex() {
 function RootDocument() {
   return (
     <AuthKitProvider>
-      <ConvexAuthBridge>
+      <PostHogProvider>
+        <ConvexAuthBridge>
         <html lang="en" className="dark">
           <head>
             <HeadContent />
@@ -99,6 +102,7 @@ function RootDocument() {
           </body>
         </html>
       </ConvexAuthBridge>
+      </PostHogProvider>
     </AuthKitProvider>
   );
 }

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -1,5 +1,6 @@
 import { getAuth } from "@workos/authkit-tanstack-react-start";
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import { PostHogIdentity } from "@/components/posthog-identity";
 
 export const Route = createFileRoute("/_protected")({
   component: RouteComponent,
@@ -16,5 +17,10 @@ export const Route = createFileRoute("/_protected")({
 });
 
 function RouteComponent() {
-  return <Outlet />;
+  return (
+    <>
+      <PostHogIdentity />
+      <Outlet />
+    </>
+  );
 }


### PR DESCRIPTION
- PostHog singleton with dev opt-out and manual pageview capture
- PostHogProvider fires $pageview on every TanStack Router navigation
- PostHogIdentity identifies WorkOS user on auth, resets on logout
- Both wired into root layout and protected route