### PR TITLE
feat(analytics): posthog integration — react native

### DIFF
--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -6,7 +6,9 @@ import { HeroUINativeProvider } from "heroui-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 
+import { NavigationTracker } from "@/contexts/navigation-tracker";
 import { AppThemeProvider } from "@/contexts/app-theme-context";
+import { PostHogProvider } from "@/contexts/posthog-context";
 
 export const unstable_settings = {
   initialRouteName: "(drawer)",
@@ -18,15 +20,19 @@ const convex = new ConvexReactClient(env.EXPO_PUBLIC_CONVEX_URL, {
 
 function StackLayout() {
   return (
-    <Stack screenOptions={{}}>
-      <Stack.Screen name="(drawer)" options={{ headerShown: false }} />
-      <Stack.Screen name="modal" options={{ title: "Modal", presentation: "modal" }} />
-    </Stack>
+    <>
+      <NavigationTracker />
+      <Stack screenOptions={{}}>
+        <Stack.Screen name="(drawer)" options={{ headerShown: false }} />
+        <Stack.Screen name="modal" options={{ title: "Modal", presentation: "modal" }} />
+      </Stack>
+    </>
   );
 }
 
 export default function Layout() {
   return (
+    <PostHogProvider>
     <ConvexProvider client={convex}>
       <GestureHandlerRootView style={{ flex: 1 }}>
         <KeyboardProvider>
@@ -38,5 +44,6 @@ export default function Layout() {
         </KeyboardProvider>
       </GestureHandlerRootView>
     </ConvexProvider>
+    </PostHogProvider>
   );
 }

--- a/apps/native/contexts/navigation-tracker.tsx
+++ b/apps/native/contexts/navigation-tracker.tsx
@@ -7,8 +7,8 @@ export function NavigationTracker() {
   const pathname = usePathname();
 
   useEffect(() => {
-    posthog.capture("$screen", { $screen_name: pathname });
-  }, [pathname]);
+    posthog?.capture("$screen", { $screen_name: pathname });
+  }, [pathname, posthog]);
 
   return null;
 }

--- a/apps/native/contexts/navigation-tracker.tsx
+++ b/apps/native/contexts/navigation-tracker.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { usePostHog } from "posthog-react-native";
+import { usePathname } from "expo-router";
+
+export function NavigationTracker() {
+  const posthog = usePostHog();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    posthog.capture("$screen", { $screen_name: pathname });
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/native/contexts/posthog-context.tsx
+++ b/apps/native/contexts/posthog-context.tsx
@@ -1,7 +1,11 @@
+import type { ReactNode } from "react";
+
 import { PostHogProvider as BaseProvider } from "posthog-react-native";
 import { env } from "@avm-daily/env/native";
 
-export function PostHogProvider({ children }: { children: React.ReactNode }) {
+export function PostHogProvider({ children }: { children: ReactNode }) {
+  if (!env.EXPO_PUBLIC_POSTHOG_KEY) return <>{children}</>;
+
   return (
     <BaseProvider
       apiKey={env.EXPO_PUBLIC_POSTHOG_KEY}

--- a/apps/native/contexts/posthog-context.tsx
+++ b/apps/native/contexts/posthog-context.tsx
@@ -1,0 +1,16 @@
+import { PostHogProvider as BaseProvider } from "posthog-react-native";
+import { env } from "@avm-daily/env/native";
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <BaseProvider
+      apiKey={env.EXPO_PUBLIC_POSTHOG_KEY}
+      options={{
+        host: env.EXPO_PUBLIC_POSTHOG_HOST,
+        captureAppLifecycleEvents: true,
+      }}
+    >
+      {children}
+    </BaseProvider>
+  );
+}


### PR DESCRIPTION
- PostHogProvider wraps app with lifecycle event capture
- NavigationTracker fires $screen on every Expo Router pathname change
- Both wired into root _layout.tsx