### PR TITLE
feat(observability): posthog and axiom setup — convex backend

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -41,6 +41,9 @@ import type * as kpis from "../kpis.js";
 import type * as kyc from "../kyc.js";
 import type * as kycDocuments from "../kycDocuments.js";
 import type * as kycInternal from "../kycInternal.js";
+import type * as lib_axiomAction from "../lib/axiomAction.js";
+import type * as lib_logger from "../lib/logger.js";
+import type * as posthog from "../posthog.js";
 import type * as risk from "../risk.js";
 import type * as savingsPlanRules from "../savingsPlanRules.js";
 import type * as savingsPlanTemplates from "../savingsPlanTemplates.js";
@@ -115,6 +118,9 @@ declare const fullApi: ApiFromModules<{
   kyc: typeof kyc;
   kycDocuments: typeof kycDocuments;
   kycInternal: typeof kycInternal;
+  "lib/axiomAction": typeof lib_axiomAction;
+  "lib/logger": typeof lib_logger;
+  posthog: typeof posthog;
   risk: typeof risk;
   savingsPlanRules: typeof savingsPlanRules;
   savingsPlanTemplates: typeof savingsPlanTemplates;
@@ -210,4 +216,5 @@ export declare const components: {
   workOSAuthKit: import("@convex-dev/workos-authkit/_generated/component.js").ComponentApi<"workOSAuthKit">;
   auditLog: import("convex-audit-log/_generated/component.js").ComponentApi<"auditLog">;
   crons: import("@convex-dev/crons/_generated/component.js").ComponentApi<"crons">;
+  posthog: import("@posthog/convex/_generated/component.js").ComponentApi<"posthog">;
 };

--- a/packages/backend/convex/convex.config.ts
+++ b/packages/backend/convex/convex.config.ts
@@ -2,6 +2,7 @@ import { defineApp } from "convex/server";
 
 import workosAuthkit from "@convex-dev/workos-authkit/convex.config";
 import aggregate from "@convex-dev/aggregate/convex.config.js";
+import posthog from "@posthog/convex/convex.config.js";
 import auditLog from "convex-audit-log/convex.config";
 import crons from "@convex-dev/crons/convex.config";
 
@@ -55,5 +56,8 @@ app.use(auditLog);
 
 // Crons
 app.use(crons);
+
+// PostHog analytics
+app.use(posthog);
 
 export default app;

--- a/packages/backend/convex/lib/axiomAction.ts
+++ b/packages/backend/convex/lib/axiomAction.ts
@@ -1,27 +1,46 @@
 import { v } from "convex/values";
 import { internalAction } from "../_generated/server";
 
+const logEntryValidator = v.object({
+  timestamp: v.string(),
+  level: v.union(
+    v.literal("debug"),
+    v.literal("info"),
+    v.literal("warn"),
+    v.literal("error"),
+  ),
+  event: v.string(),
+  service: v.literal("convex"),
+  userId: v.optional(v.string()),
+  data: v.optional(v.any()),
+});
+
 export const shipLogs = internalAction({
-  args: { entries: v.array(v.any()) },
+  args: { entries: v.array(logEntryValidator) },
   handler: async (_ctx, { entries }) => {
     const token = process.env.AXIOM_TOKEN;
     const dataset = process.env.AXIOM_DATASET;
     if (!token || !dataset) return;
 
-    const res = await fetch(
-      `https://api.axiom.co/v1/datasets/${dataset}/ingest`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
+    try {
+      const res = await fetch(
+        `https://api.axiom.co/v1/datasets/${dataset}/ingest`,
+        {
+          method: "POST",
+          signal: AbortSignal.timeout(5000),
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(entries),
         },
-        body: JSON.stringify(entries),
-      },
-    );
+      );
 
-    if (!res.ok) {
-      console.error("[axiom] ingest failed", res.status, await res.text());
+      if (!res.ok) {
+        console.error("[axiom] ingest failed", res.status, await res.text());
+      }
+    } catch (err) {
+      console.error("[axiom] ingest error", err);
     }
   },
 });

--- a/packages/backend/convex/lib/axiomAction.ts
+++ b/packages/backend/convex/lib/axiomAction.ts
@@ -1,0 +1,27 @@
+import { v } from "convex/values";
+import { internalAction } from "../_generated/server";
+
+export const shipLogs = internalAction({
+  args: { entries: v.array(v.any()) },
+  handler: async (_ctx, { entries }) => {
+    const token = process.env.AXIOM_TOKEN;
+    const dataset = process.env.AXIOM_DATASET;
+    if (!token || !dataset) return;
+
+    const res = await fetch(
+      `https://api.axiom.co/v1/datasets/${dataset}/ingest`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(entries),
+      },
+    );
+
+    if (!res.ok) {
+      console.error("[axiom] ingest failed", res.status, await res.text());
+    }
+  },
+});

--- a/packages/backend/convex/lib/logger.ts
+++ b/packages/backend/convex/lib/logger.ts
@@ -1,0 +1,26 @@
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface ConvexLogEntry {
+  timestamp: string;
+  level: LogLevel;
+  event: string;
+  service: "convex";
+  userId?: string;
+  data?: Record<string, unknown>;
+}
+
+export function buildEntry(
+  level: LogLevel,
+  event: string,
+  data?: Record<string, unknown>,
+  userId?: string,
+): ConvexLogEntry {
+  return {
+    timestamp: new Date().toISOString(),
+    level,
+    event,
+    service: "convex",
+    userId,
+    data,
+  };
+}

--- a/packages/backend/convex/posthog.ts
+++ b/packages/backend/convex/posthog.ts
@@ -1,0 +1,5 @@
+import { PostHog } from "@posthog/convex";
+
+import { components } from "./_generated/api";
+
+export const posthog = new PostHog(components.posthog);


### PR DESCRIPTION
- @posthog/convex component registered in convex.config.ts
- posthog.ts exports PostHog singleton for use in mutations/actions
- lib/logger.ts: buildEntry helper for structured log entries
- lib/axiomAction.ts: internalAction shipping logs to Axiom via fetch