### PR TITLE
feat(analytics): instrument business events — convex

### DIFF
--- a/packages/backend/convex/kyc.ts
+++ b/packages/backend/convex/kyc.ts
@@ -21,6 +21,7 @@ import { action, mutation, query } from "./_generated/server";
 import { KYCStatus, TABLE_NAMES } from "./shared";
 import { internal } from "./_generated/api";
 import { getAdminUser } from "./utils";
+import { posthog } from "./posthog";
 
 function toDomainUser(user: ConvexUser): DomainUser {
   return {
@@ -292,6 +293,17 @@ export const adminReviewKyc = mutation({
       approved: args.approved,
       reason: args.reason,
       reviewedBy: admin._id,
+    });
+
+    await posthog.capture(ctx, {
+      distinctId: String(admin._id),
+      event: "admin_kyc_reviewed",
+      properties: {
+        targetUserId: String(args.userId),
+        approved: args.approved,
+        reason: args.reason,
+        documentsReviewed: result.documentsReviewed,
+      },
     });
 
     return {

--- a/packages/backend/convex/kyc.ts
+++ b/packages/backend/convex/kyc.ts
@@ -295,16 +295,20 @@ export const adminReviewKyc = mutation({
       reviewedBy: admin._id,
     });
 
-    await posthog.capture(ctx, {
-      distinctId: String(admin._id),
-      event: "admin_kyc_reviewed",
-      properties: {
-        targetUserId: String(args.userId),
-        approved: args.approved,
-        reason: args.reason,
-        documentsReviewed: result.documentsReviewed,
-      },
-    });
+    try {
+      await posthog.capture(ctx, {
+        distinctId: String(admin._id),
+        event: "admin_kyc_reviewed",
+        properties: {
+          targetUserId: String(args.userId),
+          approved: args.approved,
+          reason: args.reason,
+          documentsReviewed: result.documentsReviewed,
+        },
+      });
+    } catch (err) {
+      console.error("[posthog] capture failed", err);
+    }
 
     return {
       userId: args.userId,

--- a/packages/backend/convex/kycDocuments.ts
+++ b/packages/backend/convex/kycDocuments.ts
@@ -11,6 +11,7 @@ import { createConvexAuditLogService } from "./adapters/auditLogAdapter";
 import { createConvexUserRepository } from "./adapters/userAdapters";
 import { ensureAuthedUser, getAdminUser, getUser } from "./utils";
 import { mutation, query } from "./_generated/server";
+import { posthog } from "./posthog";
 import {
   bankAccountDocumentType,
   ALLOWED_EXTENSIONS,
@@ -124,6 +125,16 @@ export const uploadDocument = mutation({
         fileName: args.fileName,
         fileSize: args.fileSize,
         mimeType: args.mimeType,
+      });
+
+      await posthog.capture(ctx, {
+        distinctId: String(user._id),
+        event: "kyc_document_uploaded",
+        properties: {
+          documentType: args.documentType,
+          fileSize: args.fileSize,
+          mimeType: args.mimeType,
+        },
       });
 
       return {

--- a/packages/backend/convex/kycDocuments.ts
+++ b/packages/backend/convex/kycDocuments.ts
@@ -127,15 +127,19 @@ export const uploadDocument = mutation({
         mimeType: args.mimeType,
       });
 
-      await posthog.capture(ctx, {
-        distinctId: String(user._id),
-        event: "kyc_document_uploaded",
-        properties: {
-          documentType: args.documentType,
-          fileSize: args.fileSize,
-          mimeType: args.mimeType,
-        },
-      });
+      try {
+        await posthog.capture(ctx, {
+          distinctId: String(user._id),
+          event: "kyc_document_uploaded",
+          properties: {
+            documentType: args.documentType,
+            fileSize: args.fileSize,
+            mimeType: args.mimeType,
+          },
+        });
+      } catch (err) {
+        console.error("[posthog] capture failed", err);
+      }
 
       return {
         _id: document._id as KycDocumentId,

--- a/packages/backend/convex/savingsPlans.ts
+++ b/packages/backend/convex/savingsPlans.ts
@@ -19,6 +19,7 @@ import { createConvexUserRepository } from "./adapters/userAdapters";
 import { TABLE_NAMES, planStatus, txnType } from "./shared";
 import { postTransactionEntry } from "./transactions";
 import { getAdminUser, getUser } from "./utils";
+import { posthog } from "./posthog";
 
 import {
   createRecordSavingsPlanContributionUseCase,
@@ -543,6 +544,15 @@ export const create = mutation({
         created._id as UserSavingsPlanId,
       );
       await syncSavingsPlanInsert(ctx, doc);
+      await posthog.capture(ctx, {
+        distinctId: String(user._id),
+        event: "savings_plan_created",
+        properties: {
+          planId: String(created._id),
+          templateId: args.templateId,
+          targetKobo: Number(args.customTargetKobo ?? 0),
+        },
+      });
       return serializePlanSummary(doc);
     } catch (error) {
       toConvexError(error);
@@ -673,6 +683,14 @@ export const close = mutation({
         ctx,
         updated._id as UserSavingsPlanId,
       );
+      await posthog.capture(ctx, {
+        distinctId: String(user._id),
+        event: "savings_plan_closed",
+        properties: {
+          planId: String(args.planId),
+          status: doc.status,
+        },
+      });
       return serializePlanSummary(doc);
     } catch (error) {
       toConvexError(error);

--- a/packages/backend/convex/savingsPlans.ts
+++ b/packages/backend/convex/savingsPlans.ts
@@ -544,15 +544,21 @@ export const create = mutation({
         created._id as UserSavingsPlanId,
       );
       await syncSavingsPlanInsert(ctx, doc);
-      await posthog.capture(ctx, {
-        distinctId: String(user._id),
-        event: "savings_plan_created",
-        properties: {
-          planId: String(created._id),
-          templateId: args.templateId,
-          targetKobo: Number(args.customTargetKobo ?? 0),
-        },
-      });
+      try {
+        await posthog.capture(ctx, {
+          distinctId: String(user._id),
+          event: "savings_plan_created",
+          properties: {
+            planId: String(created._id),
+            templateId: args.templateId,
+            ...(args.customTargetKobo !== undefined && {
+              targetKobo: args.customTargetKobo.toString(),
+            }),
+          },
+        });
+      } catch (err) {
+        console.error("[posthog] capture failed", err);
+      }
       return serializePlanSummary(doc);
     } catch (error) {
       toConvexError(error);
@@ -683,14 +689,18 @@ export const close = mutation({
         ctx,
         updated._id as UserSavingsPlanId,
       );
-      await posthog.capture(ctx, {
-        distinctId: String(user._id),
-        event: "savings_plan_closed",
-        properties: {
-          planId: String(args.planId),
-          status: doc.status,
-        },
-      });
+      try {
+        await posthog.capture(ctx, {
+          distinctId: String(user._id),
+          event: "savings_plan_closed",
+          properties: {
+            planId: String(args.planId),
+            status: doc.status,
+          },
+        });
+      } catch (err) {
+        console.error("[posthog] capture failed", err);
+      }
       return serializePlanSummary(doc);
     } catch (error) {
       toConvexError(error);

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -159,11 +159,15 @@ export const upsertFromWorkOS = internalMutation({
       await syncUserInsert(ctx, newUser);
     }
 
-    await posthog.capture(ctx, {
-      distinctId: String(userId),
-      event: "user_signed_up",
-      properties: { workosId: args.workosId, status: "pending_kyc" },
-    });
+    try {
+      await posthog.capture(ctx, {
+        distinctId: String(userId),
+        event: "user_signed_up",
+        properties: { workosId: args.workosId, status: "pending_kyc" },
+      });
+    } catch (err) {
+      console.error("[posthog] capture failed", err);
+    }
 
     return userId;
   },
@@ -234,16 +238,20 @@ export const processKycResult = internalMutation({
     const updatedUser = await ensureUser(ctx, args.userId);
     await syncUserUpdate(ctx, oldUser, updatedUser);
 
-    await posthog.capture(ctx, {
-      distinctId: String(args.userId),
-      event: "kyc_completed",
-      properties: {
-        approved: args.approved,
-        reason: args.reason,
-        documentsReviewed: result.documentsReviewed,
-        providerReference: args.providerReference,
-      },
-    });
+    try {
+      await posthog.capture(ctx, {
+        distinctId: String(args.userId),
+        event: "kyc_completed",
+        properties: {
+          approved: args.approved,
+          reason: args.reason,
+          documentsReviewed: result.documentsReviewed,
+          providerReference: args.providerReference,
+        },
+      });
+    } catch (err) {
+      console.error("[posthog] capture failed", err);
+    }
 
     await auditLog.log(ctx, {
       action: args.approved

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -12,6 +12,7 @@ import { createConvexUserRepository } from "./adapters/userAdapters";
 import { buildUserProfileSyncAuditChange } from "./userAudit";
 import { ensureUser, getAdminUser, getUser } from "./utils";
 import { auditLog } from "./auditLog";
+import { posthog } from "./posthog";
 
 import {
   syncUserInsert,
@@ -158,6 +159,12 @@ export const upsertFromWorkOS = internalMutation({
       await syncUserInsert(ctx, newUser);
     }
 
+    await posthog.capture(ctx, {
+      distinctId: String(userId),
+      event: "user_signed_up",
+      properties: { workosId: args.workosId, status: "pending_kyc" },
+    });
+
     return userId;
   },
 });
@@ -226,6 +233,17 @@ export const processKycResult = internalMutation({
 
     const updatedUser = await ensureUser(ctx, args.userId);
     await syncUserUpdate(ctx, oldUser, updatedUser);
+
+    await posthog.capture(ctx, {
+      distinctId: String(args.userId),
+      event: "kyc_completed",
+      properties: {
+        approved: args.approved,
+        reason: args.reason,
+        documentsReviewed: result.documentsReviewed,
+        providerReference: args.providerReference,
+      },
+    });
 
     await auditLog.log(ctx, {
       action: args.approved

--- a/packages/backend/convex/withdrawals.ts
+++ b/packages/backend/convex/withdrawals.ts
@@ -514,16 +514,19 @@ export const request = mutation({
         result.withdrawal._id as WithdrawalId,
       );
       await syncWithdrawalInsert(ctx, created);
-      await posthog.capture(ctx, {
-        distinctId: String(user._id),
-        event: "withdrawal_requested",
-        properties: {
-          withdrawalId: String(created._id),
-          amountKobo: Number(args.amount_kobo),
-          method: args.method,
-        },
-      });
-
+      try {
+        await posthog.capture(ctx, {
+          distinctId: String(user._id),
+          event: "withdrawal_requested",
+          properties: {
+            withdrawalId: String(created._id),
+            amountKobo: args.amount_kobo.toString(),
+            method: args.method,
+          },
+        });
+      } catch (err) {
+        console.error("[posthog] capture failed", err);
+      }
       return await buildWithdrawalSummary(ctx, created);
     } catch (error) {
       toConvexError(error);
@@ -651,15 +654,19 @@ export const process = mutation({
         result.withdrawal._id as WithdrawalId,
       );
       await syncWithdrawalUpdate(ctx, before, after);
-      await posthog.capture(ctx, {
-        distinctId: String(admin._id),
-        event: "withdrawal_processed",
-        properties: {
-          withdrawalId: String(args.withdrawal_id),
-          amountKobo: Number(after.requested_amount_kobo),
-          userId: String(after.requested_by),
-        },
-      });
+      try {
+        await posthog.capture(ctx, {
+          distinctId: String(admin._id),
+          event: "withdrawal_processed",
+          properties: {
+            withdrawalId: String(args.withdrawal_id),
+            amountKobo: after.requested_amount_kobo.toString(),
+            userId: String(after.requested_by),
+          },
+        });
+      } catch (err) {
+        console.error("[posthog] capture failed", err);
+      }
       return await buildWithdrawalSummary(ctx, after);
     } catch (error) {
       toConvexError(error);

--- a/packages/backend/convex/withdrawals.ts
+++ b/packages/backend/convex/withdrawals.ts
@@ -34,6 +34,7 @@ import { createConvexUserRepository } from "./adapters/userAdapters";
 import { postTransactionEntry } from "./transactions";
 import { mutation, query } from "./_generated/server";
 import { getAdminUser, getUser } from "./utils";
+import { posthog } from "./posthog";
 
 import {
   assertWithdrawalAdminActionAllowed,
@@ -513,6 +514,15 @@ export const request = mutation({
         result.withdrawal._id as WithdrawalId,
       );
       await syncWithdrawalInsert(ctx, created);
+      await posthog.capture(ctx, {
+        distinctId: String(user._id),
+        event: "withdrawal_requested",
+        properties: {
+          withdrawalId: String(created._id),
+          amountKobo: Number(args.amount_kobo),
+          method: args.method,
+        },
+      });
 
       return await buildWithdrawalSummary(ctx, created);
     } catch (error) {
@@ -641,6 +651,15 @@ export const process = mutation({
         result.withdrawal._id as WithdrawalId,
       );
       await syncWithdrawalUpdate(ctx, before, after);
+      await posthog.capture(ctx, {
+        distinctId: String(admin._id),
+        event: "withdrawal_processed",
+        properties: {
+          withdrawalId: String(args.withdrawal_id),
+          amountKobo: Number(after.requested_amount_kobo),
+          userId: String(after.requested_by),
+        },
+      });
       return await buildWithdrawalSummary(ctx, after);
     } catch (error) {
       toConvexError(error);


### PR DESCRIPTION
Events tracked via @posthog/convex in mutations:
- user_signed_up (users.ts: upsertFromWorkOS, new users only)
- kyc_completed (users.ts: processKycResult)
- kyc_document_uploaded (kycDocuments.ts: uploadDocument)
- admin_kyc_reviewed (kyc.ts: adminReviewKyc)
- savings_plan_created/closed (savingsPlans.ts)
- withdrawal_requested/processed (withdrawals.ts)