### PR TITLE
feat(backend): forward critical errors to Sentry

### DIFF
--- a/packages/backend/convex/admin.ts
+++ b/packages/backend/convex/admin.ts
@@ -4,6 +4,7 @@ import type { MutationCtx } from "./_generated/server";
 import type { AdminUserId } from "./types";
 
 import { assertSuperAdmin, getAdminUser } from "./utils";
+import { captureCriticalError } from "./sentry";
 import { internal } from "./_generated/api";
 import { auditLog } from "./auditLog";
 import {
@@ -766,6 +767,12 @@ export const inviteAdminUser = action({
           signal: AbortSignal.timeout(WORKOS_TIMEOUT_MS),
         },
       ).catch(() => undefined);
+      captureCriticalError(err, {
+        action: "inviteAdminUser",
+        stage: "insert_admin_user_after_workos_invite",
+        workos_user_id: result.workosId,
+        target_email: args.email,
+      });
       throw new ConvexError(
         "Failed to create admin user record; WorkOS user has been cleaned up. Please retry.",
       );
@@ -1067,6 +1074,12 @@ export const updateAdminUserRole = action({
           error: err instanceof Error ? err.message : String(err),
         },
       });
+      captureCriticalError(err, {
+        action: "updateAdminUserRole",
+        stage: "membership_lookup",
+        target_admin_user_id: args.id,
+        attempted_role: args.role,
+      });
       throw err;
     }
 
@@ -1092,6 +1105,12 @@ export const updateAdminUserRole = action({
             previous_role: previousRole,
             error: err instanceof Error ? err.message : String(err),
           },
+        });
+        captureCriticalError(err, {
+          action: "updateAdminUserRole",
+          stage: "role_flip",
+          target_admin_user_id: args.id,
+          attempted_role: args.role,
         });
         throw err;
       }
@@ -1128,6 +1147,12 @@ export const updateAdminUserRole = action({
             error: err instanceof Error ? err.message : String(err),
           },
         });
+        captureCriticalError(err, {
+          action: "updateAdminUserRole",
+          stage: "invite_lookup",
+          target_admin_user_id: args.id,
+          attempted_role: args.role,
+        });
         throw err;
       }
       if (invitation) {
@@ -1154,6 +1179,13 @@ export const updateAdminUserRole = action({
               previous_role: previousRole,
               error: err instanceof Error ? err.message : String(err),
             },
+          });
+          captureCriticalError(err, {
+            action: "updateAdminUserRole",
+            stage: "revoke_invite",
+            target_admin_user_id: args.id,
+            invitation_id: invitation.id,
+            attempted_role: args.role,
           });
           throw err;
         }
@@ -1183,6 +1215,13 @@ export const updateAdminUserRole = action({
               error: err instanceof Error ? err.message : String(err),
               note: "Old invite revoked. Manual re-invite required.",
             },
+          });
+          captureCriticalError(err, {
+            action: "updateAdminUserRole",
+            stage: "resend_invite",
+            target_admin_user_id: args.id,
+            attempted_role: args.role,
+            note: "Local role committed; old invite revoked; manual re-invite needed.",
           });
           throw new ConvexError(
             "Role updated locally but re-invite failed. Please manually invite the admin again.",
@@ -1268,6 +1307,10 @@ export const deactivateAdminUser = action({
           error: err instanceof Error ? err.message : String(err),
         },
       });
+      captureCriticalError(err, {
+        action: "deactivateAdminUser",
+        target_admin_user_id: args.id,
+      });
       throw err;
     }
 
@@ -1346,6 +1389,11 @@ export const reactivateAdminUser = action({
           was_suspended: wasSuspended,
           error: err instanceof Error ? err.message : String(err),
         },
+      });
+      captureCriticalError(err, {
+        action: "reactivateAdminUser",
+        target_admin_user_id: args.id,
+        was_suspended: wasSuspended,
       });
       throw err;
     }

--- a/packages/backend/convex/adminSync.ts
+++ b/packages/backend/convex/adminSync.ts
@@ -1,5 +1,6 @@
 import { internalAction, internalQuery } from "./_generated/server";
 import { RESOURCE_TYPE, TABLE_NAMES, UserStatus } from "./shared";
+import { captureCriticalError } from "./sentry";
 import { internal } from "./_generated/api";
 import { auditLog } from "./auditLog";
 
@@ -95,8 +96,17 @@ export const checkAdminRoleDrift = internalAction({
       }).catch(() => null);
 
       if (!resp || !resp.ok) {
+        const status = resp?.status ?? "network error";
         console.error(
-          `[adminSync] Failed to fetch WorkOS memberships (HTTP ${resp?.status ?? "network error"}) — aborting drift check.`,
+          `[adminSync] Failed to fetch WorkOS memberships (HTTP ${status}) — aborting drift check.`,
+        );
+        captureCriticalError(
+          new Error(`Drift check aborted: WorkOS memberships fetch failed (${status})`),
+          {
+            action: "checkAdminRoleDrift",
+            stage: "memberships_fetch",
+            http_status: resp?.status,
+          },
         );
         return;
       }

--- a/packages/backend/convex/transactions.ts
+++ b/packages/backend/convex/transactions.ts
@@ -50,6 +50,7 @@ import { createConvexSavingsPlanRepository } from "./adapters/savingsPlanAdapter
 import { createConvexEventOutboxService } from "./adapters/eventOutboxAdapter";
 import { createConvexUserRepository } from "./adapters/userAdapters";
 import { getAdminUser, getUser, isRecord } from "./utils";
+import { captureCriticalError } from "./sentry";
 import { internal } from "./_generated/api";
 import { auditLog } from "./auditLog";
 
@@ -1800,6 +1801,14 @@ export const runReconciliation = internalAction({
       const completedAt = Date.now();
       const failureMessage =
         error instanceof Error ? error.message : "Unknown error";
+
+      // Reconciliation runs hourly via cron and currently records failure to
+      // the DB without re-throwing. Without this capture, silent failures
+      // are easy to miss until a user reports a balance mismatch.
+      captureCriticalError(error, {
+        action: "runReconciliation",
+        runId,
+      });
 
       try {
         for (const issueIds of chunkArray(


### PR DESCRIPTION
## Summary

Forwards every existing "critical audit log + throw" path in the backend to Sentry. Prod failures of WorkOS sync, drift detection, and reconciliation will now surface in the Sentry dashboard with structured stage / target context — alongside the existing audit log entries, not as a replacement.

Builds on the helpers landed in [#190](https://github.com/kleva-j/ave-maria-admin/pull/190).

## Changes

### `packages/backend/convex/admin.ts` — 7 capture points across 4 actions

- **`inviteAdminUser`**: insert failure after WorkOS user creation (compensating cleanup path)
- **`updateAdminUserRole`** (5 sites): membership lookup fail · role flip fail · pending invite lookup fail · invite revoke fail · invite resend fail (the resend case keeps the new local role and instructs manual re-invite — Sentry context flags this so the runbook is clear)
- **`deactivateAdminUser`**: WorkOS sync fail
- **`reactivateAdminUser`**: WorkOS sync fail (tagged with `was_suspended` pre-state)

### `packages/backend/convex/adminSync.ts`

- `checkAdminRoleDrift` drift fetch failure. Action previously logged to console and returned silently; now also captures a synthetic `Error` so the silent abort surfaces in alerting.

### `packages/backend/convex/transactions.ts`

- `runReconciliation` catch block. The handler records failure to the DB and returns the failed run instead of re-throwing, so `withSentry` wrapping the handler would never see the exception. `captureCriticalError` inside the catch block matches the existing pattern in `admin.ts` and gives us alerting on the hourly cron that previously failed silently.

## Why capture-in-catch instead of `withSentry`

The plan originally called for wrapping `runReconciliation` with `withSentry`. After reading the handler, the existing catch already swallows the error (writes failure to the DB and returns the failed run record) — so the outer wrapper would never fire. Capturing inside the existing catch block is the smaller, equivalent change.

`withSentry` remains exported from `convex/sentry.ts` for future action handlers that DO re-throw and need flush-before-return semantics.

## Properties

- **Additive.** Every capture call sits adjacent to an existing `auditLog.log(severity: "critical")` write. Error semantics, rollback paths, and UI responses are unchanged.
- **DSN-gated.** `captureCriticalError` no-ops when `SENTRY_DSN` is unset, so dev deployments see zero overhead.
- **Never masks.** `captureCriticalError` swallows its own internal errors so a Sentry transport failure cannot block the original error from propagating.

## Test plan

- [x] `pnpm -F backend exec tsc --noEmit -p convex` exits 0
- [x] `pnpm -F backend test` — all 47 tests still pass
- [ ] Manual smoke (after Convex deployment has `SENTRY_DSN` set): force a WorkOS 500 by setting bad `WORKOS_API_KEY`, run `npx convex run adminSync:checkAdminRoleDrift` → critical event appears in Sentry tied to the `checkAdminRoleDrift` action + the existing audit log entry still emits

## Convex env vars needed at rollout

```bash
npx convex env set SENTRY_DSN "https://...@sentry.io/..."
npx convex env set SENTRY_ENVIRONMENT "production"     # or "staging"
npx convex env set SENTRY_TRACES_SAMPLE_RATE "0.1"
```