### PR TITLE
feat(web): wire sentryTanstackStart Vite plugin + release build script

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
+    "build:sentry": "SENTRY_RELEASE=$(git rev-parse HEAD) vite build",
     "serve": "vite preview",
     "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' vite dev",
     "test": "vitest run",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,12 +1,31 @@
 import tailwindcss from "@tailwindcss/vite";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import viteReact from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig({
-  plugins: [tsconfigPaths(), tailwindcss(), tanstackStart(), viteReact()],
-  server: {
-    port: 3001,
-  },
+export default defineConfig(({ mode }) => {
+  // Load all envs (no VITE_ prefix filter) so SENTRY_AUTH_TOKEN / ORG / PROJECT
+  // resolve at build time. The plugin no-ops silently when authToken is unset
+  // so local dev builds without Sentry credentials still work.
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
+    plugins: [
+      tsconfigPaths(),
+      tailwindcss(),
+      tanstackStart(),
+      viteReact(),
+      sentryTanstackStart({
+        org: env.SENTRY_ORG,
+        project: env.SENTRY_PROJECT_WEB,
+        authToken: env.SENTRY_AUTH_TOKEN,
+        telemetry: false,
+      }),
+    ],
+    server: {
+      port: 3001,
+    },
+  };
 });


### PR DESCRIPTION
## Summary

Source-map upload via the official `@sentry/tanstackstart-react/vite` plugin. Without this, prod stack traces in Sentry point to minified file/line which is useless for triage. With it, every prod build uploads source maps tagged to a release matching the deployed commit.

## Changes

- **`apps/web/vite.config.ts`** — switches from object-form `defineConfig` to function-form so `loadEnv` runs per build and `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT_WEB` resolve from `.env` at build time. `sentryTanstackStart` is the last plugin in the chain (per upstream docs). `telemetry: false` so the plugin doesn't phone home about the build itself.
- **`apps/web/package.json`** — adds `build:sentry` script that sets `SENTRY_RELEASE=$(git rev-parse HEAD)` then runs `vite build` so uploaded source maps tie to a specific release in Sentry. The plain `build` script stays unchanged for local use.

## Behavior when auth token is unset

The plugin logs `[sentry-vite-plugin] Warning: No auth token provided. Will not upload source maps.` and skips the upload step. `vite build` still exits 0. Local prod builds without Sentry credentials remain unaffected.

## Test plan

- [x] `pnpm -F web build` succeeds with token unset (plugin no-ops, no upload attempt)
- [x] Source-map `.map` files emit alongside chunks (verified in build output)
- [ ] Manual smoke (after CI/staging has `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT_WEB` set): `pnpm build:sentry` uploads source maps and tags release with commit SHA — verify a thrown error in Sentry UI symbolicates to original file/line

## Stack position

Builds on top of [#192](https://github.com/kleva-j/ave-maria-admin/pull/192) (web runtime). Independent of the native and backend sub-stacks.