### PR TITLE
feat(native): instrument Expo app with @sentry/react-native

### DIFF
--- a/apps/native/app/+error.tsx
+++ b/apps/native/app/+error.tsx
@@ -1,0 +1,40 @@
+import { Stack, router } from "expo-router";
+import { Button, Surface } from "heroui-native";
+import { useEffect } from "react";
+import { Text, View } from "react-native";
+
+import { Container } from "@/components/container";
+import { Sentry } from "@/lib/sentry";
+
+/**
+ * Expo Router error boundary. Renders when a route throws during render.
+ * Forwards the error to Sentry so the crash surfaces in the dashboard with
+ * the React component stack.
+ */
+export default function ErrorBoundary({ error }: { error: Error }) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "Error" }} />
+      <Container>
+        <View className="flex-1 justify-center items-center p-4">
+          <Surface variant="secondary" className="items-center p-6 max-w-sm rounded-lg">
+            <Text className="text-4xl mb-3">⚠️</Text>
+            <Text className="text-foreground font-medium text-lg mb-1">
+              Something went wrong
+            </Text>
+            <Text className="text-muted text-sm text-center mb-4">
+              {error.message}
+            </Text>
+            <Button size="sm" onPress={() => router.replace("/")}>
+              Go Home
+            </Button>
+          </Surface>
+        </View>
+      </Container>
+    </>
+  );
+}

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -9,6 +9,11 @@ import { KeyboardProvider } from "react-native-keyboard-controller";
 import { NavigationTracker } from "@/contexts/navigation-tracker";
 import { AppThemeProvider } from "@/contexts/app-theme-context";
 import { PostHogProvider } from "@/contexts/posthog-context";
+import { Sentry, initSentry } from "@/lib/sentry";
+
+// Initialize at module top so Sentry registers before the first render
+// frame. No-op when EXPO_PUBLIC_SENTRY_DSN is unset.
+initSentry();
 
 export const unstable_settings = {
   initialRouteName: "(drawer)",
@@ -30,7 +35,7 @@ function StackLayout() {
   );
 }
 
-export default function Layout() {
+function Layout() {
   return (
     <PostHogProvider>
     <ConvexProvider client={convex}>
@@ -47,3 +52,7 @@ export default function Layout() {
     </PostHogProvider>
   );
 }
+
+// Sentry.wrap adds automatic touch / nav instrumentation and a root error
+// boundary that forwards to Sentry. Acts as a passthrough when init is a no-op.
+export default Sentry.wrap(Layout);

--- a/apps/native/lib/sentry.ts
+++ b/apps/native/lib/sentry.ts
@@ -1,0 +1,42 @@
+import * as Sentry from "@sentry/react-native";
+import { env } from "@avm-daily/env/native";
+import { isRunningInExpoGo } from "expo";
+
+let initialized = false;
+
+/**
+ * Initialize Sentry for the React Native runtime. Idempotent + silent no-op
+ * when EXPO_PUBLIC_SENTRY_DSN is unset, so dev environments without a Sentry
+ * project remain unaffected.
+ *
+ * Expo Router projects do not need a navigation-container wrapper — navigation
+ * spans are captured automatically by the SDK.
+ */
+export function initSentry(): void {
+  if (initialized) return;
+  if (!env.EXPO_PUBLIC_SENTRY_DSN) return;
+
+  try {
+    Sentry.init({
+      dsn: env.EXPO_PUBLIC_SENTRY_DSN,
+      environment:
+        env.EXPO_PUBLIC_SENTRY_ENVIRONMENT ??
+        (__DEV__ ? "development" : "production"),
+      tracesSampleRate: env.EXPO_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
+      integrations: [Sentry.mobileReplayIntegration()],
+      // mobileReplayIntegration is masked-by-default at SDK level; keep it
+      // explicit for review clarity.
+      replaysOnErrorSampleRate: 1.0,
+      replaysSessionSampleRate: 0,
+      // Slow / frozen frames metrics. Disabled in Expo Go because native code
+      // for that integration is not bundled.
+      enableNativeFramesTracking: !isRunningInExpoGo(),
+      sendDefaultPii: false,
+    });
+    initialized = true;
+  } catch (e) {
+    console.error("[sentry] init failed", e);
+  }
+}
+
+export { Sentry };

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -19,6 +19,7 @@
     "@gorhom/bottom-sheet": "^5",
     "@react-navigation/drawer": "^7.3.9",
     "@react-navigation/elements": "^2.8.1",
+    "@sentry/react-native": "^8.14.0",
     "convex": "catalog:",
     "dotenv": "catalog:",
     "expo": "^55.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@react-navigation/elements':
         specifier: ^2.8.1
         version: 2.9.15(@react-navigation/native@7.2.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      '@sentry/react-native':
+        specifier: ^8.14.0
+        version: 8.14.0(@expo/env@2.1.1)(dotenv@17.4.2)(expo@55.0.17)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       convex:
         specifier: 'catalog:'
         version: 1.36.1(react@19.2.0)
@@ -2909,6 +2912,116 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sentry-internal/browser-utils@10.57.0':
+    resolution: {integrity: sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.57.0':
+    resolution: {integrity: sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.57.0':
+    resolution: {integrity: sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.57.0':
+    resolution: {integrity: sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg==}
+    engines: {node: '>=18'}
+
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser@10.57.0':
+    resolution: {integrity: sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==}
+    engines: {node: '>=18'}
+
+  '@sentry/cli-darwin@3.5.0':
+    resolution: {integrity: sha512-Q7WIq+SNMh/7gddovgcHUBlgzsH2jASdkxinwxoDZVNcF96gqr35QllRHkxZTt1+nLM3JytL2A+Mh9JdvMWzsA==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@3.5.0':
+    resolution: {integrity: sha512-nWlWo0qw1OqcOFR6GgcJ3KT+bMOlE3BFBtbMCxyURb4dTcT+NPy1Oe9Kk+JyWgRk1xm4CTaPXJNd2JD5V36FQA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@3.5.0':
+    resolution: {integrity: sha512-d4U64gQikZiqr63XL3suWhd28e0NQg63GX+JumRiDYCDCAF3gmdUS6BRR43lyoZm2wqhHRQSms2bMArAPTDH/w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@3.5.0':
+    resolution: {integrity: sha512-HE8zFNvg/YWudGp+pBeJSNgF/siyarnlBkWbRxz6WApsFq7uvajXPk7EqwJ0onKnzPS14OPlTtTejA3iSUuCNg==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@3.5.0':
+    resolution: {integrity: sha512-uU6h/b3SIoWysn0U6PoyUx/R5z9kU9+VcuvydjlqkZGDbbcRIxqp0T/wgB/jhXeFaSSPSFlmmkQCVYi8PXCrSw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@3.5.0':
+    resolution: {integrity: sha512-P13w9Vc/ur6rnwtiBe4wzu4M81ODhdOGc8iWpkN51gzjldjz9FF4F2UEdS9UUYBxesWJU+UF62ZVQ4H73rhS4g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@3.5.0':
+    resolution: {integrity: sha512-LZIEsJ5zMd0HAYlnG7G7OM6/AOvFaWkuBPdePZqYvtMLOUsfY7zeW8ubyZ9uCOWsj5Xc7UiDF4v0gZ45Strlkg==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@3.5.0':
+    resolution: {integrity: sha512-Dgkn60xoF7csXcKk+gRlmOA7s//7w0R3QlaXCo5RbX/c5VTbcV74r6ON7A+SKTFO9i4fEGblLlzQ0MLqrIo2sw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@3.5.0':
+    resolution: {integrity: sha512-D3N3kULOnAClRkhHKqOAcOTtDnRe7hFacdHLlSsQXAZB11Qu6VAy8mGmM3654Lq/3LHl5h8CW590JGR9E0yahQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
+  '@sentry/core@10.57.0':
+    resolution: {integrity: sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==}
+    engines: {node: '>=18'}
+
+  '@sentry/expo-upload-sourcemaps@8.14.0':
+    resolution: {integrity: sha512-caPp11nVIAHtCTaM2kTqf3wG5aAui09EbeqoBEA9//NnRkuOVuRqapfX+ABTFlnnimbBSvn3MKrQt6HTMp/ELQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@expo/env': '*'
+      dotenv: '*'
+    peerDependenciesMeta:
+      '@expo/env':
+        optional: true
+      dotenv:
+        optional: true
+
+  '@sentry/react-native@8.14.0':
+    resolution: {integrity: sha512-2OF5M1Easgo25qX5360I/zb/P8IPhu6YXTgvCQCA6AYHxZvLf/9w/Rzaa+BYl6wBnnUvserjtua1xXdSrQhQXA==}
+    hasBin: true
+    peerDependencies:
+      expo: '>=49.0.0'
+      react: '>=17.0.0'
+      react-native: '>=0.65.0'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
+  '@sentry/react@10.57.0':
+    resolution: {integrity: sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
 
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
@@ -6330,6 +6443,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -7190,6 +7306,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+    engines: {node: '>=18.17'}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -10104,6 +10224,105 @@ snapshots:
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sentry-internal/browser-utils@10.57.0':
+    dependencies:
+      '@sentry/core': 10.57.0
+
+  '@sentry-internal/feedback@10.57.0':
+    dependencies:
+      '@sentry/core': 10.57.0
+
+  '@sentry-internal/replay-canvas@10.57.0':
+    dependencies:
+      '@sentry-internal/replay': 10.57.0
+      '@sentry/core': 10.57.0
+
+  '@sentry-internal/replay@10.57.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.57.0
+      '@sentry/core': 10.57.0
+
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
+  '@sentry/browser@10.57.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.57.0
+      '@sentry-internal/feedback': 10.57.0
+      '@sentry-internal/replay': 10.57.0
+      '@sentry-internal/replay-canvas': 10.57.0
+      '@sentry/core': 10.57.0
+
+  '@sentry/cli-darwin@3.5.0':
+    optional: true
+
+  '@sentry/cli-linux-arm64@3.5.0':
+    optional: true
+
+  '@sentry/cli-linux-arm@3.5.0':
+    optional: true
+
+  '@sentry/cli-linux-i686@3.5.0':
+    optional: true
+
+  '@sentry/cli-linux-x64@3.5.0':
+    optional: true
+
+  '@sentry/cli-win32-arm64@3.5.0':
+    optional: true
+
+  '@sentry/cli-win32-i686@3.5.0':
+    optional: true
+
+  '@sentry/cli-win32-x64@3.5.0':
+    optional: true
+
+  '@sentry/cli@3.5.0':
+    dependencies:
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      undici: 6.26.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 3.5.0
+      '@sentry/cli-linux-arm': 3.5.0
+      '@sentry/cli-linux-arm64': 3.5.0
+      '@sentry/cli-linux-i686': 3.5.0
+      '@sentry/cli-linux-x64': 3.5.0
+      '@sentry/cli-win32-arm64': 3.5.0
+      '@sentry/cli-win32-i686': 3.5.0
+      '@sentry/cli-win32-x64': 3.5.0
+
+  '@sentry/core@10.57.0': {}
+
+  '@sentry/expo-upload-sourcemaps@8.14.0(@expo/env@2.1.1)(dotenv@17.4.2)':
+    dependencies:
+      '@sentry/cli': 3.5.0
+    optionalDependencies:
+      '@expo/env': 2.1.1
+      dotenv: 17.4.2
+
+  '@sentry/react-native@8.14.0(@expo/env@2.1.1)(dotenv@17.4.2)(expo@55.0.17)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/browser': 10.57.0
+      '@sentry/cli': 3.5.0
+      '@sentry/core': 10.57.0
+      '@sentry/expo-upload-sourcemaps': 8.14.0(@expo/env@2.1.1)(dotenv@17.4.2)
+      '@sentry/react': 10.57.0(react@19.2.0)
+      react: 19.2.0
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+    optionalDependencies:
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@expo/env'
+      - dotenv
+
+  '@sentry/react@10.57.0(react@19.2.0)':
+    dependencies:
+      '@sentry/browser': 10.57.0
+      '@sentry/core': 10.57.0
+      react: 19.2.0
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -13683,6 +13902,8 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-from-env@1.1.0: {}
+
   punycode@2.3.1: {}
 
   pure-rand@8.4.0: {}
@@ -14617,6 +14838,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
+
+  undici@6.26.0: {}
 
   undici@7.25.0: {}
 


### PR DESCRIPTION
## Summary

Wires the Sentry React Native SDK for the Expo Router app. All instrumentation is gated on `EXPO_PUBLIC_SENTRY_DSN` so dev environments without a Sentry project remain unaffected.

## Changes

- **`apps/native/lib/sentry.ts`** (new) — `initSentry()` helper, idempotent and DSN-gated. Configures:
  - `mobileReplayIntegration` (on-error only, 0% session sample)
  - `enableNativeFramesTracking` — disabled in Expo Go (`isRunningInExpoGo()`) because the integration's native code is not bundled there
  - `sendDefaultPii: false`
- **`apps/native/app/_layout.tsx`** — calls `initSentry()` at module top so the SDK registers before the first render frame. Default export wrapped with `Sentry.wrap(...)` which adds automatic touch / nav instrumentation and a root error boundary.
- **`apps/native/app/+error.tsx`** (new) — Expo Router error boundary that forwards render-time errors to Sentry via `captureException` and renders a fallback with the existing `Container` + `Surface` tailwind pattern from `+not-found.tsx`. Includes a "Go Home" button that resets via `router.replace("/")`.

## SDK source

Setup follows the upstream skill doc at https://skills.sentry.dev/sentry-react-native-sdk/SKILL.md — Path B (Manual — Expo Managed). `@sentry/react-native@8.14.0`. Wizard CLI not used because it requires interactive login + browser auth.

## Out of scope

- Native build wiring (Expo plugin + Metro source-map serializer) lands in [#195](https://github.com/kleva-j/ave-maria-admin/pull/195). Runtime works without it but stack traces will be against minified bundles until the build PR ships.
- Babel plugin (`@sentry/babel-plugin-component-annotate`) intentionally omitted — Sentry docs do not require it for Expo Managed, and `reactCompiler` is already enabled in `app.json`'s experiments block.

## Test plan

- [x] `pnpm -F native exec tsc --noEmit` passes for the new Sentry files (the pre-existing `todos.tsx` stub errors are unrelated)
- [ ] Manual on simulator (post-merge): `throw` from a screen → error route renders + event appears in Sentry with React component stack
- [ ] Manual: confirm app boots normally with DSN unset (silent no-op)