### PR TITLE
feat(native): wire Sentry Expo plugin + Metro source-map serializer

### DIFF
--- a/apps/native/app.json
+++ b/apps/native/app.json
@@ -8,7 +8,17 @@
     },
     "name": "avm-daily",
     "slug": "avm-daily",
-    "plugins": ["expo-font"],
+    "plugins": [
+      "expo-font",
+      [
+        "@sentry/react-native/expo",
+        {
+          "url": "https://sentry.io/",
+          "organization": "YOUR_ORG_SLUG",
+          "project": "avm-daily-native"
+        }
+      ]
+    ],
     "experiments": {
       "typedRoutes": true,
       "reactCompiler": true

--- a/apps/native/metro.config.js
+++ b/apps/native/metro.config.js
@@ -1,9 +1,14 @@
-const { getDefaultConfig } = require("expo/metro-config");
+const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 const { withUniwindConfig } = require("uniwind/metro");
 const { wrapWithReanimatedMetroConfig } = require("react-native-reanimated/metro-config");
 
+// getSentryExpoConfig is a drop-in replacement for expo/metro-config's
+// getDefaultConfig — it registers Sentry's source-map serializer so the
+// SDK can map minified stack traces back to original sources during EAS
+// builds. No-op for runtime; upload only happens when SENTRY_AUTH_TOKEN
+// is set at build time.
 /** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(__dirname);
+const config = getSentryExpoConfig(__dirname);
 
 const uniwindConfig = withUniwindConfig(wrapWithReanimatedMetroConfig(config), {
   cssEntryFile: "./global.css",


### PR DESCRIPTION
## Summary

Wires the Sentry build-time pipeline for the Expo app so EAS builds emit and upload source maps. Without this, prod stack traces from PR #194's runtime instrumentation arrive in Sentry pointing at minified bundles.

## Changes

- **`apps/native/app.json`** — adds `@sentry/react-native/expo` to `expo.plugins`. Project slug pinned to `avm-daily-native`; org slug left as `"YOUR_ORG_SLUG"` placeholder to be filled by the Sentry org owner or replaced with a value pulled from env via an `app.config.ts` migration later. The plugin no-ops at runtime and only triggers source-map / dSYM upload during EAS builds when `SENTRY_AUTH_TOKEN` is present.
- **`apps/native/metro.config.js`** — swaps `getDefaultConfig` from `expo/metro-config` for `getSentryExpoConfig` from `@sentry/react-native/metro`. Drop-in replacement that registers Sentry's source-map serializer so minified stack traces symbolicate to original sources. The existing `react-native-reanimated/metro-config` + `uniwind/metro` wrap chain still composes on top.

## What's NOT in this PR

- **Babel plugin** — `@sentry/babel-plugin-component-annotate` intentionally omitted. The Sentry docs do not require it for Expo Managed and `reactCompiler` is already enabled in `app.json`.
- **`eas.json`** — does not exist in the repo today. When it is added later, inject `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT_NATIVE` into the `build.production.env` block so EAS builds upload source maps. Documented in `apps/native/.env.example`.
- **`runtimeVersion`** — skipped. EAS Updates source-map matching requires it but the app has no version field today and the docs path doesn't mandate it for basic crash reporting.

## Test plan

- [x] `node -e "require('./metro.config.js')"` loads clean — Metro chain still composes
- [x] App.json is valid JSON
- [ ] Manual: run `npx expo start` — Metro boots, no plugin error
- [ ] Manual (when EAS is wired): `eas build --profile preview` emits source maps and uploads when `SENTRY_AUTH_TOKEN` is set in the build env

## Stack position

Builds on top of [#194](https://github.com/kleva-j/ave-maria-admin/pull/194) (native runtime). Independent of the web and backend sub-stacks.