### PR TITLE
feat(backend): Novu user-notification dispatcher + delivery ledger

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -63,6 +63,7 @@ import type * as schemas_transactionReconciliationRuns from "../schemas/transact
 import type * as schemas_transactions from "../schemas/transactions.js";
 import type * as schemas_userBankAccountEvents from "../schemas/userBankAccountEvents.js";
 import type * as schemas_userBankAccounts from "../schemas/userBankAccounts.js";
+import type * as schemas_userNotificationDeliveries from "../schemas/userNotificationDeliveries.js";
 import type * as schemas_userRiskHolds from "../schemas/userRiskHolds.js";
 import type * as schemas_userSavingsPlans from "../schemas/userSavingsPlans.js";
 import type * as schemas_users from "../schemas/users.js";
@@ -72,6 +73,7 @@ import type * as shared from "../shared.js";
 import type * as transactions from "../transactions.js";
 import type * as types from "../types.js";
 import type * as userAudit from "../userAudit.js";
+import type * as userNotifications from "../userNotifications.js";
 import type * as users from "../users.js";
 import type * as utils from "../utils.js";
 import type * as verificationQueue from "../verificationQueue.js";
@@ -140,6 +142,7 @@ declare const fullApi: ApiFromModules<{
   "schemas/transactions": typeof schemas_transactions;
   "schemas/userBankAccountEvents": typeof schemas_userBankAccountEvents;
   "schemas/userBankAccounts": typeof schemas_userBankAccounts;
+  "schemas/userNotificationDeliveries": typeof schemas_userNotificationDeliveries;
   "schemas/userRiskHolds": typeof schemas_userRiskHolds;
   "schemas/userSavingsPlans": typeof schemas_userSavingsPlans;
   "schemas/users": typeof schemas_users;
@@ -149,6 +152,7 @@ declare const fullApi: ApiFromModules<{
   transactions: typeof transactions;
   types: typeof types;
   userAudit: typeof userAudit;
+  userNotifications: typeof userNotifications;
   users: typeof users;
   utils: typeof utils;
   verificationQueue: typeof verificationQueue;

--- a/packages/backend/convex/init.ts
+++ b/packages/backend/convex/init.ts
@@ -47,6 +47,11 @@ export const setup = internalAction({
         fn: internal.adminSync.checkAdminRoleDrift,
         schedule: { kind: "interval" as const, ms: 60 * 60 * 1000 }, // 1 hour
       },
+      {
+        name: "sweep user notifications",
+        fn: internal.userNotifications.sweep,
+        schedule: { kind: "interval" as const, ms: 60 * 1000 }, // 1 minute
+      },
     ];
 
     for (const job of cronJobs) {

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -3,6 +3,7 @@ import { defineSchema } from "convex/server";
 import { transaction_reconciliation_issues } from "./schemas/transactionReconciliationIssues";
 import { transaction_reconciliation_runs } from "./schemas/transactionReconciliationRuns";
 import { bank_account_document_comments } from "./schemas/bankAccountDocumentComments";
+import { user_notification_deliveries } from "./schemas/userNotificationDeliveries";
 import { user_bank_account_events } from "./schemas/userBankAccountEvents";
 import { withdrawal_reservations } from "./schemas/withdrawalReservations";
 import { bank_account_documents } from "./schemas/bankAccountDocuments";
@@ -37,6 +38,7 @@ export default defineSchema({
   [TABLE_NAMES.USER_SAVINGS_PLANS]: user_savings_plans,
   [TABLE_NAMES.USER_BANK_ACCOUNTS]: user_bank_accounts,
   [TABLE_NAMES.NOTIFICATION_EVENTS]: notification_events,
+  [TABLE_NAMES.USER_NOTIFICATION_DELIVERIES]: user_notification_deliveries,
   [TABLE_NAMES.ADMIN_ALERT_RECEIPTS]: admin_alert_receipts,
   [TABLE_NAMES.ADMIN_DASHBOARD_KPIS]: admin_dashboard_kpis,
   [TABLE_NAMES.BANK_ACCOUNT_DOCUMENTS]: bank_account_documents,

--- a/packages/backend/convex/schemas/userNotificationDeliveries.ts
+++ b/packages/backend/convex/schemas/userNotificationDeliveries.ts
@@ -1,0 +1,36 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+import { novuDeliveryStatus } from "../shared";
+
+/**
+ * Novu delivery ledger — the second consumer of the notification_events outbox.
+ *
+ * One row per (notification_event → user) fan-out. Owns its own status + retry
+ * so Novu dispatch is fully independent of the admin-alert sweep that also
+ * drains notification_events. The unique index on event_id makes enqueue
+ * idempotent: a given event produces at most one delivery row.
+ *
+ * The dispatcher action has no db access, so every field it needs to call
+ * Novu (subscriberId = user_id, first_name, workflow_id, payload) is
+ * denormalized onto the row at enqueue time.
+ */
+export const user_notification_deliveries = defineTable({
+  event_id: v.id("notification_events"),
+  user_id: v.id("users"), // = Novu subscriberId
+  subscriber_first_name: v.string(),
+  workflow_id: v.string(), // Novu workflow trigger identifier
+  payload: v.any(), // template vars (no BVN/NIN/account#/balance)
+  novu_status: novuDeliveryStatus,
+  novu_transaction_id: v.optional(v.string()),
+  attempt_count: v.number(),
+  next_attempt_at: v.number(),
+  last_error: v.optional(v.string()),
+  created_at: v.number(),
+  sent_at: v.optional(v.number()),
+})
+  .index("by_event_id", ["event_id"])
+  .index("by_novu_status_and_next_attempt_at", [
+    "novu_status",
+    "next_attempt_at",
+  ]);

--- a/packages/backend/convex/shared.ts
+++ b/packages/backend/convex/shared.ts
@@ -22,9 +22,29 @@ export const TABLE_NAMES = {
   BANK_ACCOUNT_DOCUMENT_COMMENTS: "bank_account_document_comments",
   TRANSACTION_RECONCILIATION_RUNS: "transaction_reconciliation_runs",
   TRANSACTION_RECONCILIATION_ISSUES: "transaction_reconciliation_issues",
+  USER_NOTIFICATION_DELIVERIES: "user_notification_deliveries",
 } as const;
 
 export type TableName = (typeof TABLE_NAMES)[keyof typeof TABLE_NAMES];
+
+// Novu delivery ledger status. Separate from notification_events'
+// processing_status so the Novu dispatch is an independent consumer of the
+// shared event outbox and never contends with the admin-alert sweep.
+export const NovuDeliveryStatus = {
+  PENDING: "pending",
+  SENT: "sent",
+  FAILED: "failed",
+  SKIPPED: "skipped",
+} as const;
+
+export const novuDeliveryStatus = v.union(
+  v.literal(NovuDeliveryStatus.PENDING),
+  v.literal(NovuDeliveryStatus.SENT),
+  v.literal(NovuDeliveryStatus.FAILED),
+  v.literal(NovuDeliveryStatus.SKIPPED),
+);
+
+export type NovuDeliveryStatus = typeof novuDeliveryStatus.type;
 
 // Constants for file validation
 export const MAX_FILE_SIZE = 5 * 1024 * 1024;

--- a/packages/backend/convex/userNotifications.ts
+++ b/packages/backend/convex/userNotifications.ts
@@ -1,0 +1,337 @@
+/**
+ * Novu in-app notification dispatch for END USERS.
+ *
+ * Second consumer of the notification_events outbox (the first is the
+ * admin-alert sweep in adminAlerts.ts). This module never touches that sweep
+ * or the events' processing_status — it maintains its own delivery ledger
+ * (user_notification_deliveries) with independent status + retry.
+ *
+ * Pipeline (driven by a 60s cron → `sweep`):
+ *   1. _enqueueUserDeliveries — scan recent user-facing events, fan out one
+ *      delivery row per event (idempotent via the unique by_event_id index),
+ *      denormalizing everything the action needs (subscriberId, first_name,
+ *      workflow_id, template payload).
+ *   2. _listPendingDeliveries — due pending rows.
+ *   3. sweep dispatches each to Novu via fetch, marks sent/failed.
+ *
+ * All of it is a silent no-op when NOVU_SECRET_KEY is unset.
+ *
+ * fetch() is available in the Convex default runtime — no "use node" needed,
+ * which lets the query/mutation exports live in the same file as the action.
+ */
+import { v } from "convex/values";
+
+import type { Doc, Id } from "./_generated/dataModel";
+
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+  query,
+} from "./_generated/server";
+import { NotificationEventType, NovuDeliveryStatus, TABLE_NAMES } from "./shared";
+import { internal } from "./_generated/api";
+import { getUser } from "./utils";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** The 7 outcome events that produce a user notification. */
+const USER_FACING_EVENT_TYPES = new Set<string>([
+  NotificationEventType.WITHDRAWAL_APPROVED,
+  NotificationEventType.WITHDRAWAL_REJECTED,
+  NotificationEventType.WITHDRAWAL_PROCESSED,
+  NotificationEventType.WITHDRAWAL_PROCESSING_FAILED,
+  NotificationEventType.KYC_DECISION_APPLIED,
+  NotificationEventType.BANK_VERIFICATION_APPROVED,
+  NotificationEventType.BANK_VERIFICATION_REJECTED,
+]);
+
+/**
+ * Novu workflow trigger identifier per event type. These MUST match the
+ * workflow IDs created in the Novu dashboard (kebab-case of the event type).
+ */
+function workflowIdFor(eventType: string): string {
+  return eventType.replace(/_/g, "-");
+}
+
+const ENQUEUE_SCAN_LIMIT = 200;
+const DISPATCH_BATCH = 50;
+const MAX_ATTEMPTS = 5;
+const RETRY_BACKOFF_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// HMAC (Web Crypto — available in the Convex default runtime)
+// ---------------------------------------------------------------------------
+
+async function hmacSha256Hex(secret: string, message: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(message));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// Public query: inbox auth for the <Inbox/> component
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the secure-mode credentials the Novu <Inbox/> needs.
+ * subscriberId = the caller's Convex users._id; subscriberHash = HMAC of it
+ * keyed by NOVU_SECRET_KEY, computed server-side so the secret never ships.
+ *
+ * The client supplies applicationIdentifier itself (public VITE/EXPO env).
+ * Returns null when Novu is not configured so the client can hide the bell.
+ */
+export const getNovuInboxAuth = query({
+  args: {},
+  returns: v.union(
+    v.object({ subscriberId: v.string(), subscriberHash: v.string() }),
+    v.null(),
+  ),
+  handler: async (ctx) => {
+    const user = await getUser(ctx);
+    const secret = process.env.NOVU_SECRET_KEY;
+    if (!secret) return null;
+    const subscriberId = String(user._id);
+    const subscriberHash = await hmacSha256Hex(secret, subscriberId);
+    return { subscriberId, subscriberHash };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Internal: enqueue deliveries from recent events
+// ---------------------------------------------------------------------------
+
+function buildTemplatePayload(
+  event: Doc<"notification_events">,
+  withdrawal: Doc<"withdrawals"> | null,
+): Record<string, unknown> {
+  const p = (event.payload ?? {}) as Record<string, unknown>;
+  switch (event.event_type) {
+    case NotificationEventType.WITHDRAWAL_APPROVED:
+    case NotificationEventType.WITHDRAWAL_REJECTED:
+    case NotificationEventType.WITHDRAWAL_PROCESSED:
+    case NotificationEventType.WITHDRAWAL_PROCESSING_FAILED:
+      return {
+        status: p.status ?? withdrawal?.status,
+        // amount as string — kobo is int64 (bigint) and not JSON-serializable.
+        amount_kobo:
+          withdrawal != null ? String(withdrawal.requested_amount_kobo) : null,
+        reference: withdrawal?.reference ?? null,
+        path: `/withdrawals/${String(p.withdrawal_id ?? "")}`,
+      };
+    case NotificationEventType.KYC_DECISION_APPLIED:
+      return {
+        approved: p.approved ?? null,
+        new_status: p.new_status ?? null,
+        path: "/kyc",
+      };
+    case NotificationEventType.BANK_VERIFICATION_APPROVED:
+      return { path: "/bank-accounts" };
+    case NotificationEventType.BANK_VERIFICATION_REJECTED:
+      return {
+        rejection_reason: p.rejection_reason ?? null,
+        path: "/bank-accounts",
+      };
+    default:
+      return { path: "/" };
+  }
+}
+
+export const _enqueueUserDeliveries = internalMutation({
+  args: {},
+  returns: v.object({ enqueued: v.number() }),
+  handler: async (ctx) => {
+    const now = Date.now();
+    // Bounded recent window. The sweep runs every 60s; user-facing event
+    // volume is far below this window, so nothing is missed at current scale.
+    const recent = await ctx.db
+      .query(TABLE_NAMES.NOTIFICATION_EVENTS)
+      .withIndex("by_occurred_at")
+      .order("desc")
+      .take(ENQUEUE_SCAN_LIMIT);
+
+    let enqueued = 0;
+    for (const event of recent) {
+      if (!USER_FACING_EVENT_TYPES.has(event.event_type)) continue;
+
+      const existing = await ctx.db
+        .query(TABLE_NAMES.USER_NOTIFICATION_DELIVERIES)
+        .withIndex("by_event_id", (q) => q.eq("event_id", event._id))
+        .unique();
+      if (existing) continue;
+
+      const payload = (event.payload ?? {}) as Record<string, unknown>;
+      const rawUserId = payload.user_id;
+      if (typeof rawUserId !== "string") continue; // unresolvable → skip silently
+
+      const userId = rawUserId as Id<"users">;
+      const user = await ctx.db.get(userId);
+
+      // Withdrawal display fields (amount/reference) aren't in the event
+      // payload — read the doc to enrich the Novu template.
+      let withdrawal: Doc<"withdrawals"> | null = null;
+      const withdrawalId = payload.withdrawal_id;
+      if (typeof withdrawalId === "string") {
+        withdrawal = await ctx.db.get(withdrawalId as Id<"withdrawals">);
+      }
+
+      await ctx.db.insert(TABLE_NAMES.USER_NOTIFICATION_DELIVERIES, {
+        event_id: event._id,
+        user_id: userId,
+        subscriber_first_name: user?.first_name ?? "",
+        workflow_id: workflowIdFor(event.event_type),
+        payload: buildTemplatePayload(event, withdrawal),
+        // No user row → nothing to notify; record as skipped so we don't rescan.
+        novu_status: user
+          ? NovuDeliveryStatus.PENDING
+          : NovuDeliveryStatus.SKIPPED,
+        attempt_count: 0,
+        next_attempt_at: now,
+        last_error: user ? undefined : "user not found",
+        created_at: now,
+      });
+      enqueued++;
+    }
+
+    return { enqueued };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Internal: list + mark
+// ---------------------------------------------------------------------------
+
+export const _listPendingDeliveries = internalQuery({
+  args: { limit: v.number() },
+  handler: async (ctx, args): Promise<Doc<"user_notification_deliveries">[]> => {
+    const now = Date.now();
+    return await ctx.db
+      .query(TABLE_NAMES.USER_NOTIFICATION_DELIVERIES)
+      .withIndex("by_novu_status_and_next_attempt_at", (q) =>
+        q.eq("novu_status", NovuDeliveryStatus.PENDING).lte("next_attempt_at", now),
+      )
+      .take(args.limit);
+  },
+});
+
+export const _markDeliverySent = internalMutation({
+  args: {
+    id: v.id("user_notification_deliveries"),
+    transactionId: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.id, {
+      novu_status: NovuDeliveryStatus.SENT,
+      novu_transaction_id: args.transactionId,
+      sent_at: Date.now(),
+      last_error: undefined,
+    });
+    return null;
+  },
+});
+
+export const _markDeliveryFailed = internalMutation({
+  args: { id: v.id("user_notification_deliveries"), error: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.id);
+    if (!row) return null;
+    const attempt = row.attempt_count + 1;
+    const exhausted = attempt >= MAX_ATTEMPTS;
+    await ctx.db.patch(args.id, {
+      attempt_count: attempt,
+      novu_status: exhausted
+        ? NovuDeliveryStatus.FAILED
+        : NovuDeliveryStatus.PENDING,
+      next_attempt_at: Date.now() + RETRY_BACKOFF_MS * attempt,
+      last_error: args.error,
+    });
+    return null;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Cron entrypoint: enqueue + dispatch
+// ---------------------------------------------------------------------------
+
+export const sweep = internalAction({
+  args: {},
+  returns: v.object({
+    enqueued: v.number(),
+    dispatched: v.number(),
+    failed: v.number(),
+  }),
+  handler: async (
+    ctx,
+  ): Promise<{ enqueued: number; dispatched: number; failed: number }> => {
+    const secret = process.env.NOVU_SECRET_KEY;
+    if (!secret) {
+      console.log("[novu] NOVU_SECRET_KEY not set — skipping user notification sweep.");
+      return { enqueued: 0, dispatched: 0, failed: 0 };
+    }
+
+    const { enqueued }: { enqueued: number } = await ctx.runMutation(
+      internal.userNotifications._enqueueUserDeliveries,
+      {},
+    );
+
+    const pending: Doc<"user_notification_deliveries">[] = await ctx.runQuery(
+      internal.userNotifications._listPendingDeliveries,
+      { limit: DISPATCH_BATCH },
+    );
+
+    const apiUrl = process.env.NOVU_API_URL ?? "https://api.novu.co";
+    let dispatched = 0;
+    let failed = 0;
+
+    for (const d of pending) {
+      try {
+        const resp = await fetch(`${apiUrl}/v1/events/trigger`, {
+          method: "POST",
+          headers: {
+            Authorization: `ApiKey ${secret}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: d.workflow_id,
+            to: {
+              subscriberId: String(d.user_id),
+              firstName: d.subscriber_first_name || undefined,
+            },
+            payload: d.payload,
+          }),
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!resp.ok) throw new Error(`Novu trigger failed (HTTP ${resp.status})`);
+        const body = (await resp.json().catch(() => ({}))) as {
+          data?: { transactionId?: string };
+        };
+        await ctx.runMutation(internal.userNotifications._markDeliverySent, {
+          id: d._id,
+          transactionId: body.data?.transactionId,
+        });
+        dispatched++;
+      } catch (err) {
+        await ctx.runMutation(internal.userNotifications._markDeliveryFailed, {
+          id: d._id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        failed++;
+      }
+    }
+
+    return { enqueued, dispatched, failed };
+  },
+});


### PR DESCRIPTION
## Summary

Backend dispatch for Novu in-app notifications to **end users**. Adds a second, independent consumer of the existing `notification_events` outbox that fans user-facing events out to Novu. Zero changes to the admin-alert sweep or the event emit sites — the events are already being emitted.

Stacked on [#196](https://github.com/kleva-j/ave-maria-admin/pull/196).

## Architecture

```
business mutation → eventOutboxService.append(notification_events)   [UNCHANGED]

cron (60s) → internal.userNotifications.sweep (action)
  1. _enqueueUserDeliveries — scan recent user-facing events, insert one
     user_notification_deliveries row each (idempotent via unique by_event_id)
  2. _listPendingDeliveries — due pending rows
  3. POST /v1/events/trigger per row via fetch → _markDeliverySent / _markDeliveryFailed
```

Why a separate delivery table: `notification_events` has a single `processing_status` drained by the admin-alert sweep. A dedicated ledger gives Novu its own status + retry with zero contention.

## Changes

- **`schemas/userNotificationDeliveries.ts`** (new) — delivery ledger. Unique `by_event_id` index makes enqueue idempotent. Denormalizes everything the dispatcher action needs (subscriberId = `users._id`, first_name, workflow_id, payload) because actions have no db access.
- **`shared.ts`** — `TABLE_NAMES.USER_NOTIFICATION_DELIVERIES` + `NovuDeliveryStatus` (pending / sent / failed / skipped).
- **`userNotifications.ts`** (new):
  - `getNovuInboxAuth` (query) — secure-mode creds for `<Inbox/>`: `subscriberId = users._id`, `subscriberHash = HMAC-SHA256(subscriberId, NOVU_SECRET_KEY)` via Web Crypto (available in the default runtime). Returns null when Novu unset so the client hides the bell. Secret never ships.
  - `_enqueueUserDeliveries` — fans the 7 outcome events into delivery rows. `user_id` comes straight off the event payload; withdrawal amount/reference enriched from the withdrawal doc. Amount stored as string (int64 isn't JSON-safe).
  - `_listPendingDeliveries` / `_markDeliverySent` / `_markDeliveryFailed` — capped exponential backoff (5 attempts).
  - `sweep` (internalAction) — `fetch` to Novu (no SDK, no `"use node"`). Silent no-op when `NOVU_SECRET_KEY` unset.
- **`init.ts`** — registers the `sweep user notifications` cron (60s).

## Events → workflows

7 outcome events, each mapping to a Novu workflow id (kebab-case of the event type — must match the dashboard):

`withdrawal_approved`, `withdrawal_rejected`, `withdrawal_processed`, `withdrawal_processing_failed`, `kyc_decision_applied`, `bank_verification_approved`, `bank_verification_rejected`.

## PII

Payloads carry only status / amount / reference / first_name / deep-link path. **Never** BVN, NIN, account numbers, or balances.

## Test plan

- [x] `pnpm -F backend exec tsc --noEmit -p convex` clean
- [x] `pnpm -F backend test` — 47/47 pass
- [ ] After `npx convex env set NOVU_SECRET_KEY ...` and creating the 7 workflows in the Novu dashboard: `npx convex run userNotifications:sweep` triggers pending deliveries; rows go pending → sent with a `novu_transaction_id`
- [ ] Unset key → sweep logs a skip, no crash